### PR TITLE
Removal of option which is set by default

### DIFF
--- a/book/src/lshort.sty
+++ b/book/src/lshort.sty
@@ -19,7 +19,7 @@
 \RequirePackage{calc}
 \RequirePackage{lastpage}
 \RequirePackage{amsmath,latexsym,amsthm}
-\RequirePackage[retainorgcmds]{IEEEtrantools}
+\RequirePackage{IEEEtrantools}
 \RequirePackage[psamsfonts]{amssymb}
 \RequirePackage{cmmib57}% Use blueSky cmmib5 cmmib7 cmsy
 \RequirePackage[all]{xy}

--- a/book/src/math.tex
+++ b/book/src/math.tex
@@ -656,7 +656,7 @@ package\footnote{The \pai{IEEEtrantools} package may not be included in your set
 \pai{IEEEtrantools}. Include the following line in the header of
 your document: \small
 \begin{verbatim}
-\usepackage[retainorgcmds]{IEEEtrantools}
+\usepackage{IEEEtrantools}
 \end{verbatim}
 \normalsize
 


### PR DESCRIPTION
Good afternoon, Tobi! You've accepted some small contributions by me ten years ago :smile: I hope you're doing well.

This pull request is about a small simplification. The `retainorgcmds` option is set by default in the `IEEEtrantools` package and can be omitted.

Quoting [`CTAN://macros/latex/contrib/IEEEtran/tools/changelog.txt`](http://ftp.cc.uoc.gr/mirrors/CTAN/macros/latex/contrib/IEEEtran/tools/changelog.txt)
> 12/2012 V1.3 (V1.8 of `IEEEtran.cls`) changes:
> 
> 1. No longer redefines the standard LaTeX itemize, enumerate and description (IED) lists by default. (e.g., the older package option `retainorgcmds` is now the default behavior.)