### PR TITLE
Documentation fix for "new command" example

### DIFF
--- a/book/src/custom.tex
+++ b/book/src/custom.tex
@@ -79,10 +79,9 @@ This is ``\tnss'' \ldots{}
 \end{example}
 
 The next example illustrates how to define a new
-command that takes one argument.
-The \verb|#1| tag gets replaced by the argument you specify.
-If you wanted to use more than one argument, use \verb|#2| and
-so on.
+command that takes two arguments.
+The \verb|#1| tag gets replaced by the first argument you specify,
+\verb|#2| with the second argument, and so on.
 
 \begin{example}
 \newcommand{\txsit}[2]


### PR DESCRIPTION
An example in the "New Commands" section defines a new command that takes two arguments, however, the documentation incorrectly said that it takes only one argument. Change the documentation to say that the new command takes two arguments.