### PR TITLE
Fix TeX version to 3.14159265 in "TeX" subsection

### DIFF
--- a/book/src/things.tex
+++ b/book/src/things.tex
@@ -28,7 +28,7 @@ with some slight enhancements added in 1989 to better support 8-bit
 characters and multiple languages. \TeX{} is renowned for being
 extremely stable, for running on many different kinds of computers,
 and for being virtually bug free. The version number of \TeX{} is
-converging to $\pi$ and is now at $3.141592653$.
+converging to $\pi$ and is now at $3.14159265$.
 
 
 \TeX{} is pronounced ``Tech,'' with a ``ch'' as in the German word


### PR DESCRIPTION
In Chapter "Things You Need to Know", section "A Bit of History",
subsection "TeX", the following sentence appears:

> The version number of TeX is converging to pi and is now at
> 3.141592653.

The above mentioned version number was added to the document's source
code in commit ce8067ff89c12af56c84de3fd905366e3321c91e on 16 Mar 2011.

However, there is no evidence that the above version number is indeed
the current version of TeX. In fact, the TeX source code available at
<http://mirrors.ctan.org/systems/knuth/dist/tex/tex.web> shows that the
latest version is 3.14159265 instead. Here is the relevant comment line
from the source code:

    % Version 3.14159265 was similar (January 2014).

This version number is currently shown as the latest stable release of
TeX in the Wikipedia article on TeX too. To verify this, visit the URL
<https://en.wikipedia.org/w/index.php?title=TeX&oldid=952481389> that
shows the latest revision of the Wikipedia article on TeX as of writing
this commit.

This commit fixes the current version number of TeX mentioned in the
document from 3.141592653 to 3.14159265.