### PR TITLE
Use booktabs format for consistent tables

### DIFF
--- a/book/src/custom.tex
+++ b/book/src/custom.tex
@@ -274,14 +274,15 @@ switch to another font for math typesetting you need another
 special set of commands; refer to Table~\ref{mathfonts}.
 
 \begin{table}[!bp]
-\caption{Fonts.} \label{fonts}
-\begin{lined}{12cm}
+  \centering
+  \caption{Fonts.} \label{fonts}
 %
 % Alan suggested not to tell about the other form of the command
 % e.g. \verb|\sffamily| or \verb|\bfseries|. This seems a good thing to me.
 %
 \begin{tabular}{@{}rl@{\qquad}rl@{}}
-\fni{textrm}\verb|{...}|        &       \textrm{\wi{roman}}&
+  \toprule
+  \fni{textrm}\verb|{...}|        &       \textrm{\wi{roman}}&
 \fni{textsf}\verb|{...}|        &       \textsf{\wi{sans serif}}\\
 \fni{texttt}\verb|{...}|        &       \texttt{typewriter}\\[6pt]
 \fni{textmd}\verb|{...}|        &       \textmd{medium}&
@@ -290,46 +291,46 @@ special set of commands; refer to Table~\ref{mathfonts}.
 \fni{textit}\verb|{...}|        &       \textit{\wi{italic}}\\
 \fni{textsl}\verb|{...}|        &       \textsl{\wi{slanted}}&
 \fni{textsc}\verb|{...}|        &       \textsc{\wi{Small Caps}}\\[6pt]
-\fni{textnormal}\verb|{...}|    &       \textnormal{document} font &&
+\fni{textnormal}\verb|{...}|    &       \textnormal{document} font && \\
+  \bottomrule
 \end{tabular}
 
 \bigskip
-\end{lined}
 \end{table}
 
 
 \begin{table}[!bp]
+  \centering
 \index{font size}
 \caption{Font Sizes.} \label{sizes}
-\begin{lined}{12cm}
-\begin{tabular}{@{}ll}
-\fni{tiny}      & \tiny        tiny font \\
-\fni{scriptsize}   & \scriptsize  very small font\\
-\fni{footnotesize} & \footnotesize  quite small font \\
-\fni{small}        &  \small            small font \\
-\fni{normalsize}   &  \normalsize  normal font \\
-\fni{large}        &  \large       large font
+\begin{tabular}{@{}llll@{}}
+  \toprule
+  \fni{tiny}      & \tiny        tiny font &
+  \fni{Large}        &  \Large       larger font \\
+  \fni{scriptsize}   & \scriptsize  very small font &
+  \fni{LARGE}        &  \LARGE       very large font \\
+  \fni{footnotesize} & \footnotesize  quite small font &
+  \multirow{2}{*}{\fni{huge}}         &  \multirow{2}{*}{\huge        huge} \\
+  \fni{small}        &  \small            small font && \\
+  \fni{normalsize}   &  \normalsize  normal font &
+  \multirow{2}{*}{\fni{Huge}}         &  \multirow{2}{*}{\Huge        largest} \\
+  \fni{large}        &  \large       large font  && \\
+  \bottomrule
 \end{tabular}%
-\qquad\begin{tabular}{ll@{}}
-\fni{Large}        &  \Large       larger font \\[5pt]
-\fni{LARGE}        &  \LARGE       very large font \\[5pt]
-\fni{huge}         &  \huge        huge \\[5pt]
-\fni{Huge}         &  \Huge        largest
-\end{tabular}
-
 \bigskip
-\end{lined}
 \end{table}
 
-\begin{table}[!tbp]
-\caption{Absolute Point Sizes in Standard Classes.}\label{tab:pointsizes}
+\begin{table}[!tb]
+  \centering
+  \caption{Absolute Point Sizes in Standard Classes.}\label{tab:pointsizes}
 \label{tab:sizes}
-\begin{lined}{12cm}
-\begin{tabular}{lrrr}
-\multicolumn{1}{c}{size} &
+\begin{tabular}{@{}lrrr@{}}
+  \toprule
+  \multicolumn{1}{c}{size} &
 \multicolumn{1}{c}{10pt (default) } &
            \multicolumn{1}{c}{11pt option}  &
            \multicolumn{1}{c}{12pt option}\\
+           \midrule
 \verb|\tiny|       & 5pt  & 6pt & 6pt\\
 \verb|\scriptsize| & 7pt  & 8pt & 8pt\\
 \verb|\footnotesize| & 8pt & 9pt & 10pt \\
@@ -340,24 +341,26 @@ special set of commands; refer to Table~\ref{mathfonts}.
 \verb|\LARGE|      & 17pt & 17pt & 20pt\\
 \verb|\huge|       & 20pt & 20pt & 25pt\\
 \verb|\Huge|       & 25pt & 25pt & 25pt\\
+  \bottomrule
 \end{tabular}
 
 \bigskip
-\end{lined}
 \end{table}
 
 
 \begin{table}[!bp]
-\caption{Math Fonts.} \label{mathfonts}
-\begin{lined}{0.7\textwidth}
-\begin{tabular}{@{}ll@{}}
-\fni{mathrm}\verb|{...}|&     $\mathrm{Roman\ Font}$\\
-\fni{mathbf}\verb|{...}|&     $\mathbf{Boldface\ Font}$\\
-\fni{mathsf}\verb|{...}|&     $\mathsf{Sans\ Serif\ Font}$\\
-\fni{mathtt}\verb|{...}|&     $\mathtt{Typewriter\ Font}$\\
-\fni{mathit}\verb|{...}|&     $\mathit{Italic\ Font}$\\
-\fni{mathcal}\verb|{...}|&    $\mathcal{CALLIGRAPHIC\ FONT}$\\
-\fni{mathnormal}\verb|{...}|& $\mathnormal{Normal\ Font}$\\
+  \centering
+  \caption{Math Fonts.} \label{mathfonts}
+  \begin{tabular}{@{}ll@{}}
+  \toprule
+  \fni{mathrm}\verb|{...}|&     $\mathrm{Roman\ Font}$\\
+  \fni{mathbf}\verb|{...}|&     $\mathbf{Boldface\ Font}$\\
+  \fni{mathsf}\verb|{...}|&     $\mathsf{Sans\ Serif\ Font}$\\
+  \fni{mathtt}\verb|{...}|&     $\mathtt{Typewriter\ Font}$\\
+  \fni{mathit}\verb|{...}|&     $\mathit{Italic\ Font}$\\
+  \fni{mathcal}\verb|{...}|&    $\mathcal{CALLIGRAPHIC\ FONT}$\\
+  \fni{mathnormal}\verb|{...}|& $\mathnormal{Normal\ Font}$\\
+  \bottomrule
 \end{tabular}
 
 %\begin{tabular}{@{}lll@{}}
@@ -374,7 +377,6 @@ special set of commands; refer to Table~\ref{mathfonts}.
 %\end{tabular}
 
 \bigskip
-\end{lined}
 \end{table}
 
 In connection with the font size commands, \wi{curly braces} play a
@@ -572,18 +574,18 @@ of 1.5 cm.
 \suppressfloats
 \begin{table}[tbp]
 \caption{\TeX{} Units.} \label{units}\index{units}
-\begin{lined}{9.5cm}
 \begin{tabular}{@{}ll@{}}
+\toprule
 \texttt{mm} & millimetre $\approx 1/25$~inch \quad \demowidth{1mm} \\
 \texttt{cm} & centimetre = 10~mm  \quad \demowidth{1cm}                     \\
 \texttt{in} & inch $=$ 25.4~mm \quad \demowidth{1in}                    \\
 \texttt{pt} & point $\approx 1/72$~inch $\approx \frac{1}{3}$~mm  \quad\demowidth{1pt}\\
 \texttt{em} & approx width of an `M' in the current font \quad \demowidth{1em}\\
-\texttt{ex} & approx height of an `x' in the current font \quad \demowidth{1ex}
+\texttt{ex} & approx height of an `x' in the current font \quad \demowidth{1ex}\\
+\bottomrule
 \end{tabular}
 
 \bigskip
-\end{lined}
 \end{table}
 
 \label{cmd:stretch}

--- a/book/src/lshort.sty
+++ b/book/src/lshort.sty
@@ -60,6 +60,10 @@
 \RequirePackage{hologo} % for \XeTeX logo *ak*
 \RequirePackage{verbatim}
 \RequirePackage{fancyhdr}
+\RequirePackage{booktabs}
+\RequirePackage{caption}
+\RequirePackage{multirow}
+\captionsetup{tableposition=top}
 \RequirePackage{calc}
 \RequirePackage{lastpage}
 \RequirePackage{amsmath,latexsym,amsthm}

--- a/book/src/spec.tex
+++ b/book/src/spec.tex
@@ -86,11 +86,12 @@ commands at the points in the text that you want the final index entries to
 point to.  Table~\ref{index} explains the syntax with several examples.
 
 \begin{table}[!tp]
+  \centering
 \caption{Index Key Syntax Examples.}
 \label{index}
-\begin{center}
 \begin{tabular}{@{}lll@{}}
-  \textbf{Example} &\textbf{Index Entry} &\textbf{Comment}\\\hline
+  \toprule
+  Example &Index Entry &Comment\\\midrule
   \rule{0pt}{1.05em}\verb|\index{hello}| &hello, 1 &Plain entry\\
 \verb|\index{hello!Peter}|   &\hspace*{2ex}Peter, 3 &Subentry under `hello'\\
 \verb|\index{Sam@\textsl{Sam}}|     &\textsl{Sam}, 2& Formatted entry\\
@@ -98,9 +99,9 @@ point to.  Table~\ref{index} explains the syntax with several examples.
 \verb|\index{Kaese@\textbf{K\"ase}}|     &\textbf{K\"ase}, 33& Formatted entry\\
 \verb.\index{ecole@\'ecole}.     &\'ecole, 4& Formatted entry\\
 \verb.\index{Jenny|textbf}.     &Jenny, \textbf{3}& Formatted page number\\
-\verb.\index{Joe|textit}.     &Joe, \textit{5}& Formatted page number
+\verb.\index{Joe|textit}.     &Joe, \textit{5}& Formatted page number\\
+\bottomrule
 \end{tabular}
-\end{center}
 \end{table}
 
 When the input file is processed with \LaTeX{}, each \verb|\index|

--- a/book/src/typeset.tex
+++ b/book/src/typeset.tex
@@ -360,9 +360,10 @@ If you prefer a Euro symbol that matches your font, use the option
 %slanted and bold variants of the Euro symbol.
 
 \begin{table}[!htbp]
+  \centering
 \caption{A bag full of Euro symbols} \label{eurosymb}
-\begin{lined}{10cm}
-\begin{tabular}{llccc}
+\begin{tabular}{@{}llccc@{}}
+\toprule
 LM+textcomp  &\verb+\texteuro+ & \huge\texteuro &\huge\sffamily\texteuro
                                                 &\huge\ttfamily\texteuro\\
 eurosym      &\verb+\euro+ & \huge\officialeuro &\huge\sffamily\officialeuro
@@ -375,9 +376,9 @@ $[$gen$]$eurosym &\verb+\euro+ & \huge\geneuro  &\huge\sffamily\geneuro
 %                                             & \huge\ttfamily\EUROSANS \\
 %marvosym     &\verb+\EURtm+  & \huge\mvchr101  &\huge\mvchr101
 %                                               &\huge\mvchr101
+\bottomrule
 \end{tabular}
 \medskip
-\end{lined}
 \end{table}
 
 \subsection{Ellipsis (\texorpdfstring{\ldots}{...})}
@@ -433,9 +434,10 @@ Sch\"onbrunner Schlo\ss{}
 Stra\ss e
 \end{example}
 \begin{table}[!hbp]
+  \centering
 \caption{Accents and Special Characters.} \label{accents}
-\begin{lined}{10cm}
-\begin{tabular}{*4{cl}}
+\begin{tabular}{@{}*4{cl}@{}}
+  \toprule
 \mstA{\`o} & \mstA{\'o} & \mstA{\^o} & \mstA{\~o} \\
 \mstA{\=o} & \mstA{\.o} & \mstA{\"o} & \mstB{\c}{c}\\[6pt]
 \mstB{\u}{o} & \mstB{\v}{o} & \mstB{\H}{o} & \mstB{\c}{o} \\
@@ -443,14 +445,14 @@ Stra\ss e
 \mstA{\oe}  &  \mstA{\OE} & \mstA{\ae} & \mstA{\AE} \\
 \mstA{\aa} &  \mstA{\AA} \\[6pt]
 \mstA{\o}  & \mstA{\O} & \mstA{\l} & \mstA{\L} \\
-\mstA{\i}  & \mstA{\j} & !` & \verb|!`| & ?` & \verb|?`|
+\mstA{\i}  & \mstA{\j} & !` & \verb|!`| & ?` & \verb|?`| \\
+\bottomrule
 \end{tabular}
 \index{dotless \i{} and \j}\index{Scandinavian letters}
 \index{ae@\ae}\index{umlaut}\index{grave}\index{acute}
 \index{oe@\oe}\index{aa@\aa}
 
 \bigskip
-\end{lined}
 \end{table}
 
 \section{International Language Support}
@@ -1246,18 +1248,19 @@ most important keys.
 \end{enumerate}
 
 \begin{table}[tb]
+\centering
 \caption{Key Names for \textsf{graphicx} Package.}
 \label{keyvals}
-\begin{lined}{9cm}
-\begin{tabular}{@{}ll}
+\begin{tabular}{@{}ll@{}}
+  \toprule
 \texttt{width}& scale graphic to the specified width\\
 \texttt{height}& scale graphic to the specified height\\
 \texttt{angle}& rotate graphic counterclockwise\\
 \texttt{scale}& scale graphic \\
+\bottomrule
 \end{tabular}
 
 \bigskip
-\end{lined}
 \end{table}
 
 The example code in figure~\ref{figureex} on page~\pageref{figureex} may help to clarify things.
@@ -1311,23 +1314,23 @@ is allowed to be moved.  A \emph{placement specifier} is constructed by building
 of \emph{float-placing permissions}. See Table~\ref{tab:permiss}.
 
 \begin{table}[!bp]
+\begin{minipage}{\textwidth}
+\centering
 \caption{Float Placing Permissions.}\label{tab:permiss}
-\noindent \begin{minipage}{\textwidth}
-\medskip
-\begin{center}
 \begin{tabular}{@{}cp{8cm}@{}}
+  \toprule
 Spec&Permission to place the float \ldots\\
-\hline
-\rule{0pt}{1.05em}\texttt{h} & \emph{here} at the very place in the text
+\midrule
+\texttt{h} & \emph{here} at the very place in the text
   where it occurred.  This is useful mainly for small floats.\\[0.3ex]
 \texttt{t} & at the \emph{top} of a page\\[0.3ex]
 \texttt{b} & at the \emph{bottom} of a page\\[0.3ex]
 \texttt{p} & on a special \emph{page} containing only floats.\\[0.3ex]
 \texttt{!} & without considering most of the  internal parameters\footnote{Such as the
     maximum number of floats allowed  on one page.}, which could otherwise stop this
-  float from being placed.
+  float from being placed. \\
+  \bottomrule
 \end{tabular}
-\end{center}
 \end{minipage}
 \end{table}
 


### PR DESCRIPTION
This PR uses `booktabs` package commands instead of `lined` environment so the tables have more consistent look.