### PR TITLE
New introduction to tables

### DIFF
--- a/book/CHANGES
+++ b/book/CHANGES
@@ -12,6 +12,7 @@ UNRELEASED
 * add siunitx tutorial / marcin-serwin
 * change document font back to Latin Modern / marcin-serwin
 * update polyglossia tutorial / marcin-serwin
+* rewrite tables intro / marcin-serwin
 
 6.4 2021.03.09
 --------------

--- a/book/src/biblio.bib
+++ b/book/src/biblio.bib
@@ -420,3 +420,39 @@
   url     = {https://github.com/CTeX-org/ctex-kit},
   license = {LPPL-1.3c}
 }
+
+@software{pack:booktabs,
+  title   = {booktabs -- Publication quality tables in \LaTeX},
+  author  = {Simon Fear and Danie Els},
+  version = {1.61803398},
+  date    = {2020-01-14},
+  url     = {https://www.ctan.org/pkg/booktabs},
+  license = {LPPL-1.3c}
+}
+
+@software{pack:longtable,
+  title   = {longtable -- Allow tables to flow over page boundaries},
+  author  = {David Carlisle and The LaTeX Team},
+  version = {4.17},
+  date    = {2021-09-01},
+  url     = {https://www.ctan.org/pkg/longtable},
+  license = {LPPL-1.3c}
+}
+
+@software{pack:array,
+  title   = {array -- Extending the array and tabular environments},
+  author  = {Frank Mittelbach and The LaTeX Team},
+  version = {2.5f},
+  date    = {2021-10-04},
+  url     = {https://www.ctan.org/pkg/array},
+  license = {LPPL-1.3c}
+}
+
+@software{pack:multirow,
+  title   = {multirow -- Create tabular cells spanning multiple rows},
+  author  = {Pieter van Oostrum and Øystein Bache and Jerry Leichter},
+  version = {2.8},
+  date    = {2021-03-15},
+  url     = {https://www.ctan.org/pkg/multirow},
+  license = {LPPL-1.3c}
+}

--- a/book/src/contrib.tex
+++ b/book/src/contrib.tex
@@ -60,7 +60,6 @@ Eilinger~August,        % <eaugust@student.ethz.ch>
 Rosemary~Bailey,        % <r.a.bailey@qmw.ac.uk> 0.2
 Barbara~Beeton,         % <bnb@ams.org>
 Marc~Bevand,            % <bevand_m@epita.fr>
-Marcin~Serwin,		% @marcin-servin
 Connor~Blakey,          % it's Ligatures!
 Salvatore~Bonaccorso,   % <bonaccos@ee.ethz.ch>
 Pietro~Braione,         % <braione@elet.polimi.it>

--- a/book/src/custom.tex
+++ b/book/src/custom.tex
@@ -116,7 +116,7 @@ In order to test whether the user supplied a value, use
   \ci*{IfValueTF}[argument:m ! value version:m ! no value version:m] 
 \end{lscommand}
 macro.
-\begin{example}
+\begin{example}[examplewidth=0.4\linewidth]
 \NewDocumentCommand{\MyCommand}{o}{%
   \IfValueTF {#1} {%
     Optional argument: #1.%
@@ -153,7 +153,7 @@ values when the user does not provide them. This could be achieved by
 It works like \cargv{o} but allows to set a default
 if no value is supplied. Write
 
-\begin{example}
+\begin{example}[examplewidth=0.4\linewidth]
 \NewDocumentCommand{\txsit}{O{not so}m}
 {This is the \emph{#1}
   #2 Introduction to \LaTeXe}
@@ -171,7 +171,7 @@ starred or non-starred version of command was issued by the user. It uses
 \ci{IfBooleanTF} command (and its variations\cih{IfBooleanT}\cih{IfBooleanF})
 that works analogously to the \ci{IfValueTF} command. 
 
-\begin{example}
+\begin{example}[examplewidth=0.4\linewidth]
 \NewDocumentCommand{\txsit}{sO{not so}m}
 {This is the \emph{#2}
   #3 Introduction to \LaTeXe%
@@ -198,7 +198,7 @@ explicitly want this: \ci{RenewDocumentCommand}.
 It uses the same syntax as the \ci{NewDocumentCommand}
 command.
 
-In certain cases you might also want to use the \ci{ProvideDocumentCommand}
+In certain cases you might want to use the \ci{ProvideDocumentCommand}
 command. It works like \ci{NewDocumentCommand}, but if the command is
 already defined, \LaTeXe{} will silently ignore it.
 
@@ -209,14 +209,12 @@ following syntax:
 \begin{lscommand}
 \ci*{NewDocumentEnvironment}[name:m ! argspec:m ! at begin:m ! at end:m]
 \end{lscommand}
-
-The \carg{argspec} argument accepts the same arguments as the
+The \carg{argspec} argument is the same as in the
 \ci{NewDocumentCommand} command. The contents of \carg{at begin} and \carg{at
 end} arguments will be inserted respectively when the commands
 \ci{begin}[name] and \ci{end}[name] is encountered.
 
-The example below illustrates the usage of the \ci{NewDocumentEnvironment}
-command.
+The example below illustrates the usage of this command.
 \begin{example}
 \NewDocumentEnvironment{king}{}{%
   \emph{Listen! For the
@@ -276,7 +274,7 @@ specification: \cargv{+b}, short for body.\footnote{The \cargv{+} indicates
 that it may contain multiple paragraphs.} It is only allowed as the last
 argument in the \carg{argspec}. It allows you to receive the body of the
 environment as an argument.
-\begin{example}
+\begin{example}[examplewidth=0.4\linewidth]
 \NewDocumentEnvironment{twice}{+b} {%
   First time:\\
   #1
@@ -384,11 +382,10 @@ Now compile document like this:
 xelatex '\NewCommandCopy{\blackandwhite}{\BooleanTrue}
   \input{test.tex}'
 \end{verbatim}
-
-First the command \verb|\blackandwhite| gets defined as the copy of
-\ci{BooleanTrue} which is a special value used in \ci{IfBooleanTF} checks. Then
-the actual file is read with input. By setting \verb|\blackandwhite| to
-\ci{BooleanFalse} the colour version of the document would be produced.
+First the command \verb|\blackandwhite| is defined as the \ci{BooleanTrue} macro which
+holds a special value used in \ci{IfBooleanTF} checks. Then the actual file is
+read with input. By setting \verb|\blackandwhite| to \ci{BooleanFalse} the
+colour version of the document would be produced.
 
 \subsection{Your Own Package}
 
@@ -402,7 +399,7 @@ command to make the package available in your document.
 \begin{lined}{\textwidth}
 \begin{verbatim}
 \ProvidesExplPackage{demopack}{2022-05-05}{0.1}{%
-  Demo Package by Tobias Oetiker
+  Package by Tobias Oetiker
 }
 
 \NewDocumentCommand{\tnss}{} {
@@ -441,7 +438,7 @@ the \ai{\~} character, which normally denotes non-breaking space.\footnote{If
 The arguments are used to provide information about package in the log file. If
 you use this package and look at the log file you will find
 \begin{verbatim}
-Package: demopack 2022-05-05 v0.1 Demo Package by Tobias Oetiker
+Package: demopack 2022-05-05 v0.1 Package by Tobias Oetiker
 \end{verbatim}
 in the \eei{.log} file.
 
@@ -486,9 +483,11 @@ special set of commands; refer to Table~\ref{mathfonts}.
 % Alan suggested not to tell about the other form of the command
 % e.g. \verb|\sffamily| or \verb|\bfseries|. This seems a good thing to me.
 %
-\begin{tabular}{@{}rl@{\qquad}rl@{}}
+\begin{tabular}{@{}ll@{\qquad}ll@{}}
   \toprule
-  \fni{textrm}\verb|{...}|        &       \textrm{\wi{roman}}&
+  Command & Font &  Command & Font \\
+  \midrule
+\fni{textrm}\verb|{...}|        &       \textrm{\wi{roman}}&
 \fni{textsf}\verb|{...}|        &       \textsf{\wi{sans serif}}\\
 \fni{texttt}\verb|{...}|        &       \texttt{typewriter}\\[6pt]
 \fni{textmd}\verb|{...}|        &       \textmd{medium}&
@@ -509,18 +508,20 @@ special set of commands; refer to Table~\ref{mathfonts}.
   \centering
 \index{font size}
 \caption{Font Sizes.} \label{sizes}
-\begin{tabular}{@{}llll@{}}
+\begin{tabular}{@{}ll@{\qquad}ll@{}}
   \toprule
-  \fni{tiny}      & \tiny        tiny font &
-  \fni{Large}        &  \Large       larger font \\
-  \fni{scriptsize}   & \scriptsize  very small font &
-  \fni{LARGE}        &  \LARGE       very large font \\
-  \fni{footnotesize} & \footnotesize  quite small font &
+  Command & Size &  Command & Size \\
+  \midrule
+  \fni{tiny}      & \tiny        tiny &
+  \fni{Large}        &  \Large       larger \\
+  \fni{scriptsize}   & \scriptsize  very small &
+  \fni{LARGE}        &  \LARGE       very large \\
+  \fni{footnotesize} & \footnotesize  quite small &
   \multirow{2}{*}{\fni{huge}}         &  \multirow{2}{*}{\huge        huge} \\
-  \fni{small}        &  \small            small font && \\
-  \fni{normalsize}   &  \normalsize  normal font &
-  \multirow{2}{*}{\fni{Huge}}         &  \multirow{2}{*}{\Huge        largest} \\
-  \fni{large}        &  \large       large font  && \\
+  \fni{small}        &  \small            small && \\
+  \fni{normalsize}   &  \normalsize  normal &
+  \multirow{2}{*}{\fni{Huge}}         &  \multirow{2.2}{*}{\Huge        largest} \\
+  \fni{large}        &  \large       large  && \\
   \bottomrule
 \end{tabular}%
 \bigskip
@@ -528,25 +529,28 @@ special set of commands; refer to Table~\ref{mathfonts}.
 
 \begin{table}[!tb]
   \centering
-  \caption{Absolute Point Sizes in Standard Classes.}\label{tab:pointsizes}
+  \caption[Absolute Point Sizes in Standard Classes]{Absolute Point Sizes in
+  Standard Classes depending on the class option. The default class option is
+  \cargv{10pt}.}
+  \label{tab:pointsizes}
 \label{tab:sizes}
-\begin{tabular}{@{}lrrr@{}}
+\sisetup{table-format=2.0}
+\begin{tabular}{@{}lSSS@{}}
   \toprule
-  \multicolumn{1}{c}{size} &
-\multicolumn{1}{c}{10pt (default) } &
-           \multicolumn{1}{c}{11pt option}  &
-           \multicolumn{1}{c}{12pt option}\\
+  & \multicolumn{3}{c}{Size (\unit{pt})} \\
+  \cmidrule(l){2-4}
+  Command & {\cargv{10pt}} & {\cargv{11pt}} & {\cargv{12pt}} \\ 
            \midrule
-\verb|\tiny|       & 5pt  & 6pt & 6pt\\
-\verb|\scriptsize| & 7pt  & 8pt & 8pt\\
-\verb|\footnotesize| & 8pt & 9pt & 10pt \\
-\verb|\small|        & 9pt & 10pt & 11pt \\
-\verb|\normalsize| & 10pt & 11pt & 12pt \\
-\verb|\large|      & 12pt & 12pt & 14pt \\
-\verb|\Large|      & 14pt & 14pt & 17pt \\
-\verb|\LARGE|      & 17pt & 17pt & 20pt\\
-\verb|\huge|       & 20pt & 20pt & 25pt\\
-\verb|\Huge|       & 25pt & 25pt & 25pt\\
+\ci{tiny}       & 5  & 6 & 6\\
+\ci{scriptsize} & 7  & 8 & 8\\
+\ci{footnotesize} & 8 & 9 & 10 \\
+\ci{small}        & 9 & 10 & 11 \\
+\ci{normalsize} & 10 & 11 & 12 \\
+\ci{large}      & 12 & 12 & 14 \\
+\ci{Large}      & 14 & 14 & 17 \\
+\ci{LARGE}      & 17 & 17 & 20\\
+\ci{huge}       & 20 & 20 & 25\\
+\ci{Huge}       & 25 & 25 & 25\\
   \bottomrule
 \end{tabular}
 
@@ -557,8 +561,10 @@ special set of commands; refer to Table~\ref{mathfonts}.
 \begin{table}[!bp]
   \centering
   \caption{Math Fonts.} \label{mathfonts}
-  \begin{tabular}{@{}ll@{}}
+\begin{tabular}{@{}ll@{}}
   \toprule
+  Command & Font \\
+  \midrule
   \fni{mathrm}\verb|{...}|&     $\mathrm{Roman\ Font}$\\
   \fni{mathbf}\verb|{...}|&     $\mathbf{Boldface\ Font}$\\
   \fni{mathsf}\verb|{...}|&     $\mathsf{Sans\ Serif\ Font}$\\
@@ -788,6 +794,8 @@ of \qty{1.5}{\cm}.
 \caption{\TeX{} Units.} \label{units}\index{units}
 \begin{tabular}{@{}ll@{}}
 \toprule
+Unit & Meaning \\
+\midrule
 \texttt{mm} & millimetre $\approx$ \qty{1/25}{\in} \quad \demowidth{1mm} \\
 \texttt{cm} & centimetre = \qty{10}{mm}  \quad \demowidth{1cm} \\
 \texttt{in} & inch $=$ \qty{25.4}{\mm} \quad \demowidth{1in}                    \\

--- a/book/src/lshort.sty
+++ b/book/src/lshort.sty
@@ -280,6 +280,7 @@
     \edef\circ{\textdegree}
     \edef\ldots{...}
     \edef\ei{}
+    \edef\pai{}
     \edef\({}
     \edef\){}  
   }

--- a/book/src/lshort.sty
+++ b/book/src/lshort.sty
@@ -272,12 +272,19 @@
 %
 % propper bookmark entries in pdftex
 
-\ifx\hypersetup\undefined\else
-\pdfstringdefDisableCommands{\edef\ci{\textbackslash}}%
-\pdfstringdefDisableCommands{\edef\sim{\textasciitilde}}%
-\pdfstringdefDisableCommands{\edef\circ{\textdegree}}%
-\pdfstringdefDisableCommands{\edef\ldots{... }}%
+\ExplSyntaxOn
+\ifx\hypersetup\undefined\else  
+  \pdfstringdefDisableCommands {
+    \edef\ci{\textbackslash}
+    \edef\sim{\textasciitilde}
+    \edef\circ{\textdegree}
+    \edef\ldots{...}
+    \edef\ei{}
+    \edef\({}
+    \edef\){}  
+  }
 \fi
+\ExplSyntaxOff
 
 %\noindent\addvspace{1ex}\small #1 <\texttt{#2}>\par\addvspace{2ex}\noindnet\ignorespaces}
 %

--- a/book/src/lshort.sty
+++ b/book/src/lshort.sty
@@ -162,25 +162,30 @@
 \index{#1@\texttt{\hspace*{-1.2ex}\bs #1}}}
 \ExplSyntaxOn
 \msg_new:nnn {lshort} {invalidtype} {Invalid~argument~type~specifier:~'#1'.}
+\NewDocumentCommand{\lshort@arglist}{m}{
+  \seq_set_split:Nnn \l_tmpa_seq {!} {#1}
+  \seq_map_inline:Nn \l_tmpa_seq {
+    \exp_args:Nnx \seq_set_split:Nnn \l_tmpb_seq {\char_generate:nn{58}{12}} {##1}
+    \seq_get_left:NN \l_tmpb_seq \l_tmpa_tl
+    \seq_get_right:NN \l_tmpb_seq \l_tmpb_tl
+
+    \exp_args:Nx \str_case:nnF {\l_tmpb_tl} {
+      {o} {\texttt{[}\carg{\l_tmpa_tl}\texttt{]}}
+      {m} {\texttt{\{}\carg{\l_tmpa_tl}\texttt{\}}}
+      {p} {\texttt{(}\carg{\l_tmpa_tl}\texttt{)}}
+      {M} {\texttt{\{}\carg{\texttt{\textbackslash}\l_tmpa_tl}\texttt{\}}}
+      {vo} {\texttt{[\l_tmpa_tl]}}
+      {vm} {\texttt{\{\l_tmpa_tl\}}}
+    }{
+      \msg_error:nnx {lshort} {invalidtype} {\l_tmpb_tl}
+    }
+  }
+}
+
 \NewDocumentCommand{\ci}{smoo}{
   \cih{#2}\texttt{\bs #2}
   \IfBooleanTF {#1} {
-    \seq_set_split:Nnn \l_tmpa_seq {!} {#3}
-    \seq_map_inline:Nn \l_tmpa_seq {
-      \exp_args:Nnx \seq_set_split:Nnn \l_tmpb_seq {\char_generate:nn{58}{12}} {##1}
-      \seq_get_left:NN \l_tmpb_seq \l_tmpa_tl
-      \seq_get_right:NN \l_tmpb_seq \l_tmpb_tl
-
-      \exp_args:Nx \str_case:nnF {\l_tmpb_tl} {
-        {o} {\texttt{[}\carg{\l_tmpa_tl}\texttt{]}}
-        {m} {\texttt{\{}\carg{\l_tmpa_tl}\texttt{\}}}
-        {M} {\texttt{\{}\carg{\texttt{\textbackslash}\l_tmpa_tl}\texttt{\}}}
-        {vo} {\texttt{[\l_tmpa_tl]}}
-        {vm} {\texttt{\{\l_tmpa_tl\}}}
-      }{
-        \msg_error:nnx {lshort} {invalidtype} {\l_tmpb_tl}
-      }
-    }
+    \lshort@arglist{#3}
   }{
     \IfValueT {#3} {
       \IfValueTF {#4} {
@@ -208,10 +213,29 @@
 % Active characters
 \NewDocumentCommand{\ai}{m}{\index{#1@\texttt{#1{}}}\texttt{#1{}}}
 % Index entry for an environment
-\newcommand{\ei}[1]{%
-\index{environments!\texttt{#1}}%
-\index{#1@\texttt{#1}}%
-\texttt{#1}}
+\ExplSyntaxOn
+\NewDocumentCommand{\eih}{m} {
+  \index{environments!#1@\texttt{#1}}
+  \index{#1@\texttt{#1}}
+}
+\NewDocumentCommand{\ei}{smo} {
+  \eih{#2}
+  \IfValueTF {#3} {
+    \textbackslash{}begin\{\texttt{#2}\}
+    \IfValueT {#3} {
+      \lshort@arglist{#3}
+    }
+    \\
+    \scriptsize
+    \textbackslash{}end\{\texttt{#2}\}
+  } {
+    \texttt{#2}
+    \IfValueT {#3} {
+      \lshort@arglist{#3}
+    }
+  }
+}
+\ExplSyntaxOff
 % Indexentry for a word (Word inserted into the text)
 \newcommand{\wi}[1]{\index{#1}#1}
 %

--- a/book/src/lshort.sty
+++ b/book/src/lshort.sty
@@ -296,8 +296,8 @@
 % normal text ....
 \newcommand{\mstSC}[1]{#1&\texttt{\string#1}\hspace*{1ex}}
 % for accents in text mode
-\newcommand{\mstA}[1]{#1&\texttt{\string#1}\hspace*{1ex}}
-\newcommand{\mstB}[2]{#1#2&\texttt{\string#1{} #2}\hspace*{1ex}}
+\newcommand{\mstA}[1]{\texttt{\string#1}&#1}
+\newcommand{\mstB}[2]{\texttt{\string#1{} #2}&#1#2}
 
 \newcommand{\mstW}[2]{$#1{#2}$&
   \texttt{\string#1}\texttt{\string{\string#2\string}}\hspace*{1ex}}

--- a/book/src/lshortexample.sty
+++ b/book/src/lshortexample.sty
@@ -63,6 +63,12 @@
 
   verbatim_output_file_name .tl_set:N = \__lshortexample_verbatim_output_file,
   verbatim_output_file_name .initial:n = {\c_sys_jobname_str _output.exa},
+
+  from_page .int_set:N  = \__lshortexample_from_page,
+  from_page .initial:n  = 1,
+
+  to_page .int_set:N  = \__lshortexample_to_page,
+  to_page .initial:n  = 1,
 }
 
 \NewDocumentEnvironment{example}{!o} {
@@ -168,31 +174,40 @@
 }
 
 \cs_new:Nn \lshortexample_typeset_standalone_example:nn {
+  \group_begin:
   \tl_set:Nn \l_tmpb_tl {\file_mdfive_hash:n {#1}}
-  \begin{minipage}{\linewidth-\dim_use:N \__lshortexample_paperwidth-0.2pt}
+  \begin{minipage}{\dim_eval:n {
+    \linewidth - (\__lshortexample_paperwidth + 0.2pt) * (
+    \__lshortexample_to_page - \__lshortexample_from_page + 1)
+  }}
     \small\verbatiminput{#2}
   \end{minipage}
-  \fancyframebox{0.1pt}{0pt}{
-    \begin{minipage}{\dim_use:N \__lshortexample_paperwidth}
-      \file_if_exist:nTF {\__lshortexample_cache_dir_tl\l_tmpb_tl.pdf} {
-        \bool_set:Nn \l_tmpa_bool {\c_false_bool}
-      }{
-        \bool_set:Nn \l_tmpa_bool {\c_true_bool}
-      }
-      \bool_if:nT {
-        !\__lshortexample_cache_bool || \l_tmpa_bool
-      } {
-        \bool_if:NTF \__lshortexample_biber_run {
-          \lshortexample_compile_biber_example:nn {#1} {\l_tmpb_tl}
-        } {
-          \lshortexample_compile_example:nn {#1} {\l_tmpb_tl}
-        }
-      }
-      \includegraphics[width=\dim_use:N \__lshortexample_paperwidth]{
-        \__lshortexample_cache_dir_tl\l_tmpb_tl
-      }
-    \end{minipage}
+  \file_if_exist:nTF {\__lshortexample_cache_dir_tl\l_tmpb_tl.pdf} {
+    \bool_set:Nn \l_tmpa_bool {\c_false_bool}
+  }{
+    \bool_set:Nn \l_tmpa_bool {\c_true_bool}
   }
+  \bool_if:nT {
+    !\__lshortexample_cache_bool || \l_tmpa_bool
+  } {
+    \bool_if:NTF \__lshortexample_biber_run {
+      \lshortexample_compile_biber_example:nn {#1} {\l_tmpb_tl}
+    } {
+      \lshortexample_compile_example:nn {#1} {\l_tmpb_tl}
+    }
+  }
+  \int_step_inline:nnn {\__lshortexample_from_page} {\__lshortexample_to_page} {
+    \fancyframebox{0.1pt}{0pt}{
+      \begin{minipage}{\__lshortexample_paperwidth}
+        \includegraphics[
+          width=\__lshortexample_paperwidth,
+          page=##1]{
+          \__lshortexample_cache_dir_tl\l_tmpb_tl
+        }
+      \end{minipage}
+    }
+  }
+  \group_end:
 }
 
 \cs_new:Nn \lshortexample_typeset_example:nn {

--- a/book/src/math.tex
+++ b/book/src/math.tex
@@ -318,14 +318,16 @@ font, and not in italics as variables are, so \LaTeX{} supplies the
 following commands to typeset the most common function names:
 \index{mathematical!functions}
 
-\begin{tabular}{llllll}
-\ci{arccos} &  \ci{cos}  &  \ci{csc} &  \ci{exp} &  \ci{ker}    & \ci{limsup} \\
-\ci{arcsin} &  \ci{cosh} &  \ci{deg} &  \ci{gcd} &  \ci{lg}     & \ci{ln}     \\
-\ci{arctan} &  \ci{cot}  &  \ci{det} &  \ci{hom} &  \ci{lim}    & \ci{log}    \\
-\ci{arg}    &  \ci{coth} &  \ci{dim} &  \ci{inf} &  \ci{liminf} & \ci{max}    \\
-\ci{sinh}   & \ci{sup}   &  \ci{tan}  & \ci{tanh}&  \ci{min}    & \ci{Pr}     \\
-\ci{sec}    & \ci{sin} \\
-\end{tabular}
+\begin{center}
+  \begin{tabular}{llllll}
+    \ci{arccos} &  \ci{cos}  &  \ci{csc} &  \ci{exp} &  \ci{ker}    & \ci{limsup} \\
+    \ci{arcsin} &  \ci{cosh} &  \ci{deg} &  \ci{gcd} &  \ci{lg}     & \ci{ln}     \\
+    \ci{arctan} &  \ci{cot}  &  \ci{det} &  \ci{hom} &  \ci{lim}    & \ci{log}    \\
+    \ci{arg}    &  \ci{coth} &  \ci{dim} &  \ci{inf} &  \ci{liminf} & \ci{max}    \\
+    \ci{sinh}   & \ci{sup}   &  \ci{tan}  & \ci{tanh}&  \ci{min}    & \ci{Pr}     \\
+    \ci{sec}    & \ci{sin} \\
+  \end{tabular}
+\end{center}
 
 \begin{example}
 \begin{equation*}
@@ -1362,7 +1364,7 @@ numbers in columns formatted by \pai{siunitx}, change the
   output-decimal-marker = {,},
   unit-color = red,
 }
-\begin{tabular} {@{}cS@{}}
+\begin{tabular}{@{}cS@{}}
   \toprule
   Variable & {Value} \\
   \midrule

--- a/book/src/math.tex
+++ b/book/src/math.tex
@@ -1606,11 +1606,6 @@ This should be enough theory. The following examples should
 remove any remaining doubt, and make it clear that the
 \ci{newtheorem} command is way too complex to understand.
 
-% actually define things
-\theoremstyle{definition} \newtheorem{law}{Law}
-\theoremstyle{plain}      \newtheorem{jury}[law]{Jury}
-\theoremstyle{remark}     \newtheorem*{marg}{Margaret}
-
 First define the theorems:
 
 \begin{verbatim}
@@ -1638,7 +1633,9 @@ theorem, so it gets a number that is in sequence with
 the other ``Laws''. The argument in square brackets is used to specify 
 a title or something similar for the theorem.
 \begin{example}
+%!showbegin !hide
 \newtheorem{mur}{Murphy}[section]
+%!showend !hide
 
 \begin{mur} If there are two or 
 more ways to do something, and 

--- a/book/src/math.tex
+++ b/book/src/math.tex
@@ -1114,8 +1114,11 @@ If they are given as a decimal number, they will be displayed as such.
 \qty{60}{\degree}
 \end{example}
 
-When listing several numbers we may use the \ci{numlist}[options][numbers]
-where \carg{number} are delimited by semicolons. This command is context aware
+When listing several numbers we may use the
+\begin{lscommand}
+  \ci{numlist}[options][numbers]
+\end{lscommand}
+where \carg{numbers} are delimited by semicolons. This command is context aware
 which means it will produce correct results when used with \pai{polyglossia}.
 \begin{example}
 \numlist{1;2;3;4}
@@ -1185,31 +1188,37 @@ Litre before redefining: \unit{\L}. \\
 Litre after redefining: \unit{\L}.
 \end{example}
 
-Similarly the commands \ci{DeclareSIPrefix}, \ci{DeclareSIPower} and
-\ci{DeclareSIQualifier} allow definition of macros in case additional are
-needed.
+Similarly the commands
+\begin{lscommand}
+  \ci{DeclareSIPrefix}    \\
+  \ci{DeclareSIPower}     \\
+  \ci{DeclareSIQualifier}
+\end{lscommand}
+allow definition of unit-related macros in case additional are needed.
 \begin{example}[examplewidth=0.4\linewidth]
 \DeclareSIUnit{\pt}{pt}
 \DeclareSIPower\quartic\tothefourth{4}
 \DeclareSIPrefix\decakilo{dk}{4}
 \DeclareSIQualifier\polymer{pol}
 
-It's over \qty{9000}{\quartic\decakilo\pt\polymer}!
+It's over
+\qty{9000}{\quartic\decakilo\pt\polymer}!
 \end{example}
 
-\subsection{Table columns with numbers} \label{sec:sitables} \index{decimal alignment}
+\subsection{Table columns with numbers} \label{sec:sitables} \index{decimal
+alignment}
 
 When typesetting tables which contain numeric data it is often useful to align
 them along the decimal point, so they can be compared easily. The \pai{siunitx}
-package adds the special column specifier \cargv{S} for this purpose to the \ei{tabular}
-environment. Non numeric data must be
-surrounded by curly brackets in such columns.
+package adds the special column specifier \cargv{S} for this purpose to the
+\ei{tabular} environment. Non numeric data must be surrounded by curly brackets
+in such columns.
 \begin{example}[examplewidth=0.45\linewidth]
 \begin{tabular}{@{}lS@{}}
   \toprule
   Day & {Candy eaten (\unit{\g})} \\
   \midrule
-  Monday & 0.3011 \\
+  Monday & .3011 \\
   Tuesday & 54.86 \\
   Wednesday & 1000.9722 \\
   Thursday & -1000.9722 \\
@@ -1217,8 +1226,16 @@ surrounded by curly brackets in such columns.
 \end{tabular}
 \end{example}
 
-All the numbers in such columns are automatically parsed by \pai{siunitx} using
-current settings. In order to influence parsing\slash displaying options of a
+When presenting numeric data, such as above, it is good to remember the
+following two rules
+\begin{itemize}
+  \item Never drop the leading zero before the decimal point.
+  \item If the unit is the same in all cells put it in the heading.
+\end{itemize}
+All the numbers in \cargv{S} columns are automatically parsed by \pai{siunitx},
+which means that if we use it, the first rule will be enforced for us.
+
+In order to influence parsing\slash displaying options of a
 single column, pass them in square brackets to the column specification.
 \begin{example}[examplewidth=0.38\linewidth]
 \DeclareSIUnit{\eur}{\euro}
@@ -1317,8 +1334,8 @@ want to change the alignment use the \cargv{table-number-alignment} and
 \end{tabular}
 \end{example}
 
-It is also possible to align the numbers inside a \ci{multicol} and
-\ci{multirow}, using the \ci{tablenum} command.
+The numbers may also be aligned inside a \ci{multicol} or \ci{multirow},
+using the \ci{tablenum} command.
 \begin{example}[examplewidth=0.30\linewidth]
 \sisetup{
   table-format = 4.4e1
@@ -1456,7 +1473,7 @@ In the next example, we define a new command \ci{ud} (upright d) which produces
 $\text{d}$), so we don't have to write it every time. The \ci{NewDocumentCommand} is
 placed in the preamble.  More on
 \ci{NewDocumentCommand} in section~\ref{sec:new_commands} on page~\pageref{sec:new_commands}.
-\begin{example}
+\begin{example}[examplewidth=0.35\linewidth]
 \NewDocumentCommand{\ud}{}{\,\mathrm{d}}
 
 \begin{equation*}
@@ -1470,7 +1487,7 @@ between the integrals is too wide. You can correct it using \ci{!}, but
 the spacing, namely the \ci{iint}, \ci{iiint}, \ci{iiiint}, and \ci{idotsint}
 commands.
 
-\begin{example}
+\begin{example}[examplewidth=0.35\linewidth]
 \NewDocumentCommand{\ud}{}{\,\mathrm{d}}
 
 \begin{IEEEeqnarray*}{c}

--- a/book/src/preamble.tex
+++ b/book/src/preamble.tex
@@ -35,6 +35,10 @@
 \DeclareMathOperator{\argh}{argh}
 \DeclareMathOperator*{\nut}{Nut}
 
+\theoremstyle{definition} \newtheorem{law}{Law}
+\theoremstyle{plain}      \newtheorem{jury}[law]{Jury}
+\theoremstyle{remark}     \newtheorem*{marg}{Margaret}
+\newtheorem{mur}{Murphy}[section]
 
 \begin{document}
 \frontmatter

--- a/book/src/realworld.tex
+++ b/book/src/realworld.tex
@@ -1533,135 +1533,146 @@ Note that while you can use \ci{multicolumn} and \ci{multirow} normally within
 the \ei{longtable} environemnt, the table may get very complicated and \LaTeX{}
 will then need several passes to properly calculate the column widths.
 
-The \ei{tabular} environment can be used to typeset beautiful \wi{table}s.
-\LaTeX{} determines the width of the columns automatically.
+\subsubsection{Advanced tables and non-tables}
 
-The \emph{table spec} argument of the
+The \ci{\textbackslash} behaves very similarly to its text version. In the
+text we were able to specify the length of space between the lines. Can the
+same be done within the table? It turns out that it can, but there is one
+caveat. If you use it together with \cargv{p\{...\}} column, the space
+specified will be different depending on column order.
+\begin{example}[standalone, paperheight=2.6cm, nocache]
+\noindent %!hide
+\begin{tabular}{lp{1cm}}
+  1 & 2\newline x \\[1cm]
+  3 & 4           \\
+\end{tabular}
+\begin{tabular}{p{1cm}l}
+  2\newline x & 1 \\[1cm]
+  4           & 3 \\
+\end{tabular}
+\end{example}
+This counterintuitive behaviour is caused by the fact that the space to add is
+calculated based on the last column. In order to prevent that simply add
+\verb|\usepackage{array}| to your preamble. Since there are no downsides to
+this, it is recommended to always use this package when starting a new document
+to avoid breaking tables that rely on the original behaviour later. The
+\pai{array} package also defines some additional column specifiers.
+
+The \cargv{p\{...\}} specifier allows to insert text with linebreaks into the
+table. The text always starts from the top though, so the \pai{array} package
+defines two additional specifiers \cargv{m\{...\}} for vertically cenetred text
+and \cargv{b\{...\}} for text put vertically at the bottom.
+\begin{example}
+\begin{tabular}{
+  lp{1.4cm}m{1.4cm}b{1.4cm}
+}
+  Cell                 &
+  Top matches cell.    &
+  Center matches cell. &
+  Bottom matches cell. \\
+\end{tabular}
+\end{example}
+
+When a certain column must be formatted a certain way it is inconvenient to put
+the same commands in every cell. Moreover if you decide that something needs to
+be changed about the formatting, then you would have to edit every cell
+individually. To avoid that, the \pai{array} package defines
+\cargv{>\{\carg{cmds}\}} and \cargv{<\{\carg{cmds}\}} column specifiers which
+can be used to put some code before and after a column.
+\begin{example}
+\begin{tabular}{
+  l
+  >{\begin{em}}l<{\end{em}}
+}
+  normal text & emphasized text \\
+  normal text & emphasized text \\
+  normal text & emphasized text \\
+\end{tabular}
+\end{example}
+
+Some environments change the meaning of the \ci{\textbackslash} command thus
+making it unavailable to go to the next row. In such ocasions you may use the
+\ci{tabularnewline} command.
+\begin{example}
+\begin{tabular}{
+  >{\begin{flushleft}}
+    p{2cm}
+  <{\end{flushleft}}
+  >{\begin{flushright}}
+    p{2cm}
+  <{\end{flushright}}
+}
+  This cell will
+    be flushed left. &
+  This cell will
+    be flushed right.
+  \tabularnewline
+
+  This \\ is newline &
+  Here \\ too
+  \tabularnewline
+\end{tabular}
+\end{example}
+
+While using \cargv{>\{...\}} and \cargv{<\{...\}} comes handy if we only have
+one such column, it quickly becomes inconvenient when many column of the same
+type appear in any tables. In that case it may be desirable to use the command
 \begin{lscommand}
-\verb|\begin{tabular}[|\emph{pos}\verb|]{|\emph{table spec}\verb|}|
+  \ci*{newcolumntype}[newcolspec:m ! definition:m]
 \end{lscommand}
-\noindent 
-
-If the text in a column is too wide for the page, \LaTeX{} won't
-automatically wrap it. Using \cargv{p\{\emph{width}\}} you can define
-a special type of column which will wrap-around the text as in a normal paragraph.
-
-The \emph{pos} argument specifies the vertical position of the table
-relative to the baseline of the surrounding text.  Use one of the
-letters \cargv{t}, \cargv{b} and \cargv{c} to specify table
-alignment at the top, bottom or centre.
-
-Within a \texttt{tabular} environment, \texttt{\&} jumps to the next
-column, \ci{\bs} starts a new line and \ci{hline} inserts a horizontal
-line.  Add partial lines by using \ci{cline}\texttt{\{}$i$\texttt{-}$j$\texttt{\}},
-where $i$ and $j$ are the column numbers the line should extend over.
-
-\index{"|@ \verb."|.}
-
+where \carg{newcolspec} is a single letter used for specification of columns
+and the \carg{definition} is what should be inserted in the table when using
+it.
 \begin{example}
-\begin{tabular}{|r|l|}
-\hline
-7C0 & hexadecimal \\
-3700 & octal \\ \cline{2-2}
-11111000000 & binary \\
-\hline \hline
-1984 & decimal \\
-\hline
+\newcolumntype{e}{
+  >{\begin{em}\begin{flushleft}}
+  p{2.5cm}
+  <{\end{flushleft}\end{em}}
+}
+\begin{tabular}{ee}
+  This cell will
+    be flushed left
+    and emphasized. &
+  This cell will
+    be flushed left
+    and emphasized.
+  \tabularnewline
+
+  This cell will
+    be flushed left
+    and emphasized. &
+  This cell will
+    be flushed left
+    and emphasized.
+  \tabularnewline
 \end{tabular}
 \end{example}
 
+In order to create a tic-tac-toe grid you need to put some vertical and
+horizontal lines of the same width. In order to do so you may use the \cargv{|}
+column specifier for vertical rules and \ci{hline} for horizontal rules.
 \begin{example}
-\begin{tabular}{|p{4.7cm}|}
-\hline
-Welcome to Boxy's paragraph.
-We sincerely hope you'll
-all enjoy the show.\\
-\hline
+\begin{tabular}{c|c|c}
+  O & X & O \\
+  \hline
+  X & X & O \\
+  \hline
+  X & O & X \\
 \end{tabular}
-\end{example}
-
-The column separator can be specified with the \cargv{@\{...\}}
-construct. This command kills the inter-column space and replaces it
-with whatever is between the curly braces. 
-Common application is to suppress leading space in a table with
-\cargv{@\{\}}.
-
-\begin{example}
-\begin{tabular}{@{} l @{}}
-\hline
-no leading space\\
-\hline
+\end{example} 
+In case your grid gets more complicated you may also need the \ci{cline}[a--b]
+command which draws horizontal line that spans only over the specified rows.
+\begin{example}[examplewidth=0.4\linewidth]
+\begin{tabular}{|cccc|}
+  \cline{4-4}
+  a & a & \multicolumn{1}{c|}{a} & b \\
+  \cline{2-3}
+  a & \multicolumn{1}{|c}{b} & b & b \\
+  \cline{2-2}
+  a & a & \multicolumn{1}{|c}{b} & b \\
+  \cline{1-2}
 \end{tabular}
-\end{example}
-
-\begin{example}
-\begin{tabular}{l}
-\hline
-leading space left and right\\
-\hline
-\end{tabular}
-\end{example}
-
-%
-% This part by Mike Ressler
-%
-
-\begin{example}
-\begin{tabular}{|c|c|}
-\hline
-\multicolumn{2}{|c|}{Ene} \\
-\hline
-Mene & Muh! \\
-\hline
-\end{tabular}
-\end{example}
-
-Material typeset with the tabular environment always stays together on one
-page. If you want to typeset long tables, you might want to use the
-\pai{longtable} environments.
-
-Sometimes the default \LaTeX{} tables do feel a bit cramped. So you may want
-to give them a bit more breathing space by setting a higher
-\ci{arraystretch} and \ci{tabcolsep} value.
-
-\begin{example}[examplewidth=0.3\linewidth]
-\begin{tabular}{|l|}
-\hline
-These lines\\\hline
-are tight\\\hline
-\end{tabular}
-
-{\RenewDocumentCommand{\arraystretch}{}{1.5}
-\RenewDocumentCommand{\tabcolsep}{}{0.2cm}
-\begin{tabular}{|l|}
-\hline
-less cramped\\\hline
-table layout\\\hline
-\end{tabular}}
-
-\end{example}
-
-If you just want to grow the height of a single row in your table add an invisible vertical bar\footnote{In professional typesetting,
-this is called a \wi{strut}.}. Use a zero width \ci{rule} to implement this trick.
-
-\begin{example}
-\begin{tabular}{|c|}
-\hline
-\rule{1pt}{4ex}Pitprop \ldots\\
-\hline
-\rule{0pt}{4ex}Strut\\
-\hline
-\end{tabular}
-\end{example}
-
-The \texttt{pt} and \texttt{ex} in the example above are \TeX{} units. Read more
-on units in table \ref{units} on page \pageref{units}.
-
-A number of extra commands, enhancing the tabular environment are available
-in the \pai{booktabs} package. It makes the creation of professional looking
-tables with proper spacing quite a bit simpler.
-
-
+\end{example} 
 
 \section{Including Graphics and Images}\label{eps}
 

--- a/book/src/realworld.tex
+++ b/book/src/realworld.tex
@@ -1136,17 +1136,18 @@ within parameters of other commands.
 \subsection{Tabular}
 
 In \LaTeX{} the environment to typeset tables (and more) is called
-\ei{tabular}. While it can be used on its own, there are some spacing issues,
-so it is recommended to load \pai*{booktabs} which introduces some commands
-that solve the problem. Moreover to achieve some more advanced table layouts
-\pai*{longtable}, \pai*{array} and \pai*{multirow} will also be used in this
-chapter. If your document relies heavily on tables, then it is a good idea to
-put all of those in the preamble.
+\ei{tabular}. While it can be used on its own, the resulting table layouts look
+extremely old fashioned. We recommend to add the \pai*{booktabs} package which
+provides several commands that let you typeset beautiful modern looking tables.
+To achieve some more advanced table layouts you will also learn about the
+\pai*{longtable}, \pai*{array} and \pai*{multirow} packages in this section.
+They are so useful, that you probably want to put them all into the preamble of
+your document right away.
 
-In addition to commands description, the \pai{booktabs} package documentation
-contains guidelines on typesetting professionally looking tables. These will be
-presented here and you are encouraged to follow them if you want to present
-information contained within the tables clearly.
+In addition to the description description of the commands, the \pai{booktabs}
+package documentation \cite{pack:booktabs} contains guidelines on typesetting
+professional-looking tables. We have taken these guidelines to heart when
+writing this booklet. You will find some of them in this section.
 
 \subsubsection{Basic tables} \label{foo}
 
@@ -1155,7 +1156,7 @@ The environment \ei{tabular} has the following form
   \ei*{tabular}[pos:o ! colspec:m]
 \end{lscommand} %
 The \carg{colspec} argument, which stands for columns specifiers, defines the
-format of the table. Use an \cargv{l} for a column of left-aligned text,
+format of the columns in the table. Use an \cargv{l} for a column of left-aligned text,
 \cargv{r} for right-aligned text, and \cargv{c} for centred text. Inside the
 environment use \ai{\&} to go to next cell within the row and
 \ci{\textbackslash} to go to the next row.
@@ -1170,18 +1171,18 @@ to contain justified text with linebreaks use the \cargv{p\{\carg{width}\}}
 column specifier, where \carg{width} is the width of the column.
 \begin{example}[examplewidth=0.43\linewidth]
 \begin{tabular}{lrp{3cm}}
-  left & right & very long paragraph
+  left & right & Very long paragraph
                  that gets broken into
-                 multiple lines \\
-  1    & 2     & another one,
-                 but shorter \\
+                 multiple lines. \\
+  1    & 2     & Another one,
+                 but shorter. \\
 \end{tabular}
 \end{example}
 
 The optional \carg{pos} argument specifies the vertical position of the table
 with respect to baseline of the text. There are three possible alignments:
-\cargv{c} centre the table (the default), \cargv{t} matches the baseline of the
-top row and \cargv{b} matches the baseline of the bottom row.
+\cargv{c} centres the table (the default), \cargv{t} matches the baseline of
+the top row and \cargv{b} matches the baseline of the bottom row.
 \begin{example}[examplewidth=0.55\linewidth]
 text
 \begin{tabular}{ll}
@@ -1203,10 +1204,10 @@ text
 
 
 What we have shown so far allows aligning some items in rows and columns,
-but real tables need visible headings. To insert them use commands
+but real tables need visible headings. To insert them use the commands
 \ci{toprule}, \ci{midrule} and \ci{bottomrule} from the \pai{booktabs} package.
-All of those accept one optional argument that specifies their thickness, but
-usually their defaults are sufficient.
+All of these accept an optional argument that specifies their thickness, but
+usually the default settings are just fine.
 \begin{example}[examplewidth=0.43\linewidth]
 \begin{tabular}{lcl}
   \toprule
@@ -1220,9 +1221,9 @@ usually their defaults are sufficient.
 \end{example}
 
 With these commands you are already able to produce simple, yet nicely looking
-tables. At this point you may be thinking that this table still needs vertical
-lines between the columns but it is not the case. In fact the first rule of
-producing professionally looking tables is that you \emph{must not} use
+tables. You may be are wondering why we have not mentioned how to add vertical
+lines between the columns. Well, we did not mention them because the first rule
+of producing professional-looking tables is that you \emph{must not} use
 vertical lines.
 
 The second rule is to never use double lines such as these:
@@ -1243,12 +1244,12 @@ The second rule is to never use double lines such as these:
 As you can see the lines are already of different weight in order to signify
 their meaning. Using more lines than is necessary means cluttering the space
 without adding information. If you stick to these two rules your tables will
-look \emph{much} better.
+look quite good already.
 
-To make the tables a bit more sleek you may want to remove the padding in the
+To make the tables look even more sleek you may want to remove the padding in the
 first and last column. To control the space between the columns use the
-\cargv{\@\{\carg{sep}\}} column specifier, where \carg{sep} is either text or
-space. Space of arbitrary length can be inserted using the \ci{hspace}{width}
+\cargv{@\{\carg{sep}\}} column specifier, where \carg{sep} is either text or
+space. Space of arbitrary length can be inserted using the \ci{hspace}[width]
 command. The contents of the \carg{sep} arguments will be put between cells in
 the relevant column.
 \begin{example}[examplewidth=0.3\linewidth]
@@ -1274,16 +1275,15 @@ columns.
 \end{tabular}
 \end{example}
 
-Sometimes it may make sense to group two or more headings. To achieve this we
-need two things: the description of the group must span multiple columns and
-the line underneath the description should span only the affected columns. In
-order to achieve the first task the 
+Sometimes it may make sense to group columns under one heading. To achieve this
+we need two things: a way to group multiple heading columns and have a line
+covering the same columns, to sit underneath the merged heading cell. Use the 
 \begin{lscommand}
   \ci*{multicolumn}[ncols:m ! colspec:m ! text:m]
 \end{lscommand}
-command is used. The \carg{ncols} argument indicates how many columns should
-the \carg{text} span, while the \carg{colspec} is the column specification, the
-same as in \ei{tabular}, for the single column the \carg{text} will be put in.
+merge the cells. The \carg{ncols} argument indicates how many columns should
+the \carg{text} span, while the \carg{colspec} is the column specification for
+the new content---the same as when starting a \ei{tabular} environment.
 \begin{example}[examplewidth=0.43\linewidth]
 \begin{tabular}{@{}lll@{}}
   \toprule
@@ -1297,7 +1297,7 @@ same as in \ei{tabular}, for the single column the \carg{text} will be put in.
 \end{tabular}
 \end{example}
 
-To achieve a horizontal line that spans multiple columns, use the command
+To get a horizontal line to span multiple columns, use the command
 \begin{lscommand}
   \ci*{cmidrule}[dim:o ! trim:p ! a--b:m]
 \end{lscommand}
@@ -1331,22 +1331,21 @@ to draw the line over.
 If you need a cell to span multiple rows instead of columns, then you have to
 use package \pai{multirow}. Its main command is a little more complicated
 \begin{lscommand}
-  \ci*{multirow}[vpos:o ! nrows:m ! bigstruts:o ! width:m ! vmove:o ! text:m]
+  \ci*{multirow}[vpos:o ! nrows:m ! width:m ! vmove:o ! text:m]
 \end{lscommand}
 The arguments are
 \begin{description}
   \item[\carg{vpos}] is the vertical position of the text within the cell.
     Can be either \cargv{c} for centre (the default), \cargv{t} for top or
     \cargv{b} for bottom.
-  \item[\carg{nrows}] is the number of rows for cell to span.
-  \item[\carg{bigstruts}] is only useful if used with the \pai{bigstrut}
-    package. It will not be discussed here.
-  \item[\carg{width}] is the width of cell. In addition to lengths, you may
-    pass two special arguments here: \cargv{*} for the text natural length and
-    \cargv{=} for the same width as the column (only makes sense if the column
-    width was specified, for example via \cargv{p\{3cm\}}).
-  \item[\carg{vmove}] allows adjusting the position of the text if it is too
-    low or too tall. By default no adjusting is done.
+  \item[\carg{nrows}] is the number of rows for the new cell to span.
+  \item[\carg{width}] is the width of the cell. Apart from a regular length,
+    you can also pass two special arguments here: \cargv{*} for the natural
+    length of the text and \cargv{=} for the same width as the column (this
+    only makes sense if the column width was specified, for example via
+    \cargv{p\{3cm\}}).
+  \item[\carg{vmove}] allows adjusting the position of the text if it sits too
+    low or too high.
   \item[\carg{text}] is the text to be put in the cell.
 \end{description}
 Unlike with \ci{multicolumn} you still have to write all the cells in remaining
@@ -1367,8 +1366,9 @@ rows, but they should be empty.
   \bottomrule
 \end{tabular}
 \end{example}
-Do not overuse the \ci{multirow} when indicating values common to more than one
-row. Usually repeating the values in question makes it more readable.
+In general it is not a good idea to use the \ci{multirow} command for showing
+values common to multiple rows. Usually repeating the values in question makes
+the table more readable.
 
 When typesetting numerical data in the table, you may want to align it by
 decimal point. A way to do this (and more) is described in
@@ -1381,7 +1381,7 @@ Material typeset with the tabular environment always stays together on one
 page. This poses a problem for especially long tables. If your table is not
 very wide you may get away with it by typesetting its rows side by side. You
 should then put a bigger space between those to indicate that these are
-separate either by using \cargv{@\{...\}} or by putting empty column between
+separate either by using \cargv{@\{...\}} or by putting an empty column between
 those.
 \begin{example}[examplewidth=0.4\linewidth]
 \begin{tabular}{@{}cllcl@{}}
@@ -1397,10 +1397,10 @@ those.
 \end{tabular}
 \end{example}
 
-This approach will obviously not work for \emph{really} long tables. If you
-must tackle one of those, use the \pai{longtable} package. It defines a new
-\ei{longtable} environment that works similarly to \ei{tabular} environment,
-but allows pagebreaks inside.
+This approach will obviously not work for \emph{really} long tables. This is
+where the \pai{longtable} package shines. It defines a \ei{longtable}
+environment that works similarly to \ei{tabular} environment, but allows
+pagebreaks inside.
 
 \begin{lscommand}
   \ei*{longtable}[align:o ! colspec:m]
@@ -1493,7 +1493,7 @@ the row with them they will set the preceding rows as headers and footers of
 the table. The \ci{endhead} and \ci{endfoot} put the headers and footers on
 every page while \ci{endfirsthead} and \ci{endlastfoot} put them on the first
 and last page. An example of using these commands is presented in
-figure~\ref{ex:longtable} on page~\pageref{ex:longtable}.
+figure~\ref{ex:longtable}.
 \begin{figure}[htp]
 \begin{example}[standalone, template=empty, to_page=2, paperwidth=4.3cm] 
 %!hidebegin
@@ -1555,10 +1555,10 @@ will then need several passes to properly calculate the column widths.
 
 \subsubsection{Advanced tables and non-tables}
 
-In the text we were able to specify the length of space between the lines as an
+In regular text you can specify the amount of space between two lines as an
 optional argument to the \ci{\textbackslash} command. Can the same be done
 within the table? It turns out that it can, but there is one caveat. If you use
-it together with \cargv{p\{...\}} column, the space specified will be different
+it together with a \cargv{p\{...\}} column, the space specified will be different
 depending on column order.
 \begin{example}[standalone, paperheight=2.6cm]
 \noindent %!hide
@@ -1593,7 +1593,7 @@ and \cargv{b\{...\}} for text put vertically at the bottom.
 \end{tabular}
 \end{example}
 
-When a certain column must be formatted a certain way it is inconvenient to put
+When a column must be formatted a certain way it is inconvenient to put
 the same commands in every cell. Moreover if you decide that something needs to
 be changed about the formatting, then you would have to edit every cell
 individually. To avoid that, the \pai{array} package defines
@@ -1669,8 +1669,9 @@ it.
 \end{example}
 
 In order to create a tic-tac-toe grid you need to put some vertical and
-horizontal lines of the same width. In order to do so you may use the \cargv{|}
-column specifier for vertical rules and \ci{hline} for horizontal rules.
+horizontal lines of the same width. In order to do so you may use the
+\cargv{|}~(vertical bar) column specifier for vertical rules and \ci{hline} for
+horizontal rules.
 \begin{example}
 \begin{tabular}{c|c|c}
   O & X & O \\

--- a/book/src/realworld.tex
+++ b/book/src/realworld.tex
@@ -287,7 +287,7 @@ The names for these dashes are:
 `-' \wi{hyphen}, `--' \wi{en-dash}, `---' \wi{em-dash} and
 `$-$' \wi{minus sign}.
 
-\subsection{Tilde ($\sim$)}
+\subsection{Tilde (\(\sim\))}
 \index{URL link}\index{tilde}
 A character often seen in web addresses is the tilde. To generate
 this in \LaTeX{} use \verb|\~{}| but the result (\~{}) is not really
@@ -366,7 +366,7 @@ $[$gen$]$eurosym &\verb+\euro+ & \huge\geneuro  &\huge\sffamily\geneuro
 \medskip
 \end{table}
 
-\subsection{Ellipsis (\texorpdfstring{\ldots}{...})}
+\subsection{Ellipsis (\ldots)}
 
 On a typewriter, a \wi{comma} or a \wi{period} takes the same amount of
 space as any other letter. In book printing, these characters occupy

--- a/book/src/realworld.tex
+++ b/book/src/realworld.tex
@@ -117,20 +117,20 @@ for more information.
 In special cases it might be necessary to order \LaTeX{} to break a
 line:
 \begin{lscommand}
-\ci{\bs} or \ci{newline}
+\ci*{\bs}[length:o] or \ci{newline}
 \end{lscommand}
-\noindent starts a new line without starting a new paragraph.
+starts a new line without starting a new paragraph. The optional \carg{length}
+argument adds additional space after the line. 
 
 \begin{lscommand}
-\ci{\bs*}
+\ci*{\bs*}[length:o]
 \end{lscommand}
-\noindent additionally prohibits a page break after the forced
-line break.
+additionally prohibits a page break after the forced line break.
 
 \begin{lscommand}
 \ci{newpage}
 \end{lscommand}
-\noindent starts a new page.
+starts a new page.
 
 \begin{lscommand}
 \ci{linebreak}\verb|[|\emph{n}\verb|]|,
@@ -138,7 +138,8 @@ line break.
 \ci{pagebreak}\verb|[|\emph{n}\verb|]|,
 \ci{nopagebreak}\verb|[|\emph{n}\verb|]|
 \end{lscommand}
-\noindent suggest places where a break may (or may not) happen. They enable the author to influence their
+suggest places where a break may (or may not) happen.
+They enable the author to influence their
 actions with the optional argument \emph{n}, which can be set to a number
 between zero and four. By setting \emph{n} to a value below 4, you leave
 \LaTeX{} the option of ignoring your command if the result would look very
@@ -148,7 +149,17 @@ right border of the line and the total length of the page, as described in
 the next section; this can lead to unpleasant gaps in your text.
 If you really want to start a ``new line'' or a ``new page'', then use the
 corresponding command. Guess their names!
-
+\begin{example}[examplewidth=0.4\linewidth]
+  Lorem ipsum dolor sit amet,\\
+  consectetur adipiscing elit,\\[1cm]
+  sed do eiusmod tempor\linebreak
+  incididunt ut labore\linebreak[1]
+  et dolore magna aliqua. Ut enim
+  ad minim veniam, quis \linebreak[3]
+  nostrud exercitation ullamco laboris
+  nisi ut aliquip\linebreak
+   ex ea commodo consequat. 
+\end{example}
 
 \LaTeX{} always tries to produce the best line breaks possible. If it
 cannot find a way to break the lines in a manner that meets its high
@@ -662,7 +673,7 @@ much more limited than \pai{bidi}.} in order to support RTL languages. The
 loads \pai{bidi} this means that \pai{polyglossia} should be the last package
 loaded.)
 
-\begin{example}[standalone, template=empty, paperheight=4cm, nocache]
+\begin{example}[standalone, template=empty, paperheight=4cm]
 \documentclass{article}
 
 \usepackage{polyglossia}
@@ -1137,18 +1148,18 @@ The environment \ei{tabular} has the following form
 \end{lscommand} %
 The \carg{colspec} argument, which stands for columns specifiers, defines the
 format of the table. Use an \cargv{l} for a column of left-aligned text,
-\cargv{r} for right-aligned text, and \cargv{c} for centered text. Inside the
+\cargv{r} for right-aligned text, and \cargv{c} for centred text. Inside the
 environment use \ai{\&} to go to next cell within the row and
 \ci{\textbackslash} to go to the next row.
 \begin{example}
 \begin{tabular}{lcr}
-  left & center & right \\
+  left & centre & right \\
   1    & 2      & 3     \\
 \end{tabular}
 \end{example}
-Note that the text inside the cells will not be wrapped. If you the column to
-contain justified text with linebreaks use the \cargv{p\{\carg{dim}\}} column
-specifier, where \carg{dim} is the width of the column.
+Note that the text inside the cells will not be wrapped. If you want the column
+to contain justified text with linebreaks use the \cargv{p\{\carg{width}\}}
+column specifier, where \carg{width} is the width of the column.
 \begin{example}[examplewidth=0.43\linewidth]
 \begin{tabular}{lrp{3cm}}
   left & right & very long paragraph
@@ -1161,7 +1172,7 @@ specifier, where \carg{dim} is the width of the column.
 
 The optional \carg{pos} argument specifies the vertical position of the table
 with respect to baseline of the text. There are three possible alignments:
-\cargv{c} center the table (the default), \cargv{t} matches the baseline of the
+\cargv{c} centre the table (the default), \cargv{t} matches the baseline of the
 top row and \cargv{b} matches the baseline of the bottom row.
 \begin{example}[examplewidth=0.55\linewidth]
 text
@@ -1194,7 +1205,7 @@ usually their defaults are sufficient.
   Alignment & Letter & Niceness  \\
   \midrule
   Left      & l      & Very nice \\
-  Cener     & c      & Very nice \\
+  Centre     & c      & Very nice \\
   Right     & r      & Very nice \\
   \bottomrule
 \end{tabular}
@@ -1203,7 +1214,7 @@ usually their defaults are sufficient.
 With these commands you are already able to produce simple, yet nicely looking
 tables. At this point you may be thinking that this table still needs vertical
 lines between the columns but it is not the case. In fact the first rule of
-producing professionally looking tables is that you must \emph{not} use
+producing professionally looking tables is that you \emph{must not} use
 vertical lines.
 
 The second rule is to never use double lines such as these:
@@ -1221,7 +1232,7 @@ The second rule is to never use double lines such as these:
   \bottomrule[0.1cm]
 \end{tabular}
 \end{example}
-As you can see the lines are already of different weight in order to sifnigy
+As you can see the lines are already of different weight in order to signify
 their meaning. Using more lines than is necessary means cluttering the space
 without adding information. If you stick to these two rules your tables will
 look \emph{much} better.
@@ -1278,7 +1289,7 @@ same as in \ei{tabular}, for the single column the \carg{text} will be put in.
 \end{tabular}
 \end{example}
 
-To achive a horizontal line that spans multiple columns, use the command
+To achieve a horizontal line that spans multiple columns, use the command
 \begin{lscommand}
   \ci*{cmidrule}[dim:o ! trim:p ! a--b:m]
 \end{lscommand}
@@ -1317,7 +1328,7 @@ use package \pai{multirow}. Its main command is a little more complicated
 The arguments are
 \begin{description}
   \item[\carg{vpos}] is the vertical position of the text within the cell.
-    Can be either \cargv{c} for center (the default), \cargv{t} for top or
+    Can be either \cargv{c} for centre (the default), \cargv{t} for top or
     \cargv{b} for bottom.
   \item[\carg{nrows}] is the number of rows for cell to span.
   \item[\carg{bigstruts}] is only useful if used with the \pai{bigstrut}
@@ -1353,7 +1364,8 @@ row. Usually repeating the values in question makes it more readable.
 
 When typesetting numerical data in the table, you may want to align it by
 decimal point. A way to do this (and more) is described in
-section~\ref{sec:sitables}.
+section~\ref{sec:sitables}. The section also contains some guidelines about
+typesetting numerical data in tables.
 
 \subsubsection{Long tables}
 
@@ -1371,7 +1383,7 @@ those.
   0     & Zero  && 5     & Five  \\
   1     & One   && 6     & Six   \\
   2     & Two   && 7     & Seven \\
-  3     & Trhee && 8     & Eight \\
+  3     & Three && 8     & Eight \\
   4     & Four  && 9     & Nine  \\
   \bottomrule
 \end{tabular}
@@ -1386,8 +1398,8 @@ but allows pagebreaks inside.
   \ei*{longtable}[align:o ! colspec:m]
 \end{lscommand}
 In contrast to \ei{tabular}, the \ei{longtable} always starts a new paragraph
-and is centered by default. Thus the optional argument \carg{align} specifies
-whether the table should be centered, on the left or on the right. Use
+and is centred by default. Thus the optional argument \carg{align} specifies
+whether the table should be centred, on the left or on the right. Use
 \cargv{c}, \cargv{l} and \cargv{r} to specify this. The \carg{colspec} argument
 is the same as in the \ei{tabular} environment.
 
@@ -1475,7 +1487,7 @@ every page while \ci{endfirsthead} and \ci{endlastfoot} put them on the first
 and last page. An example of using these commands is presented in
 figure~\ref{ex:longtable} on page~\pageref{ex:longtable}.
 \begin{figure}[htp]
-\begin{example}[standalone, template=empty, to_page=2, paperwidth=4.3cm,nocache] 
+\begin{example}[standalone, template=empty, to_page=2, paperwidth=4.3cm] 
 %!hidebegin
 \documentclass{article}
 
@@ -1530,17 +1542,17 @@ figure~\ref{ex:longtable} on page~\pageref{ex:longtable}.
 \end{figure}
 
 Note that while you can use \ci{multicolumn} and \ci{multirow} normally within
-the \ei{longtable} environemnt, the table may get very complicated and \LaTeX{}
+the \ei{longtable} environment, the table may get very complicated and \LaTeX{}
 will then need several passes to properly calculate the column widths.
 
 \subsubsection{Advanced tables and non-tables}
 
-The \ci{\textbackslash} behaves very similarly to its text version. In the
-text we were able to specify the length of space between the lines. Can the
-same be done within the table? It turns out that it can, but there is one
-caveat. If you use it together with \cargv{p\{...\}} column, the space
-specified will be different depending on column order.
-\begin{example}[standalone, paperheight=2.6cm, nocache]
+In the text we were able to specify the length of space between the lines as an
+optional argument to the \ci{\textbackslash} command. Can the same be done
+within the table? It turns out that it can, but there is one caveat. If you use
+it together with \cargv{p\{...\}} column, the space specified will be different
+depending on column order.
+\begin{example}[standalone, paperheight=2.6cm]
 \noindent %!hide
 \begin{tabular}{lp{1cm}}
   1 & 2\newline x \\[1cm]
@@ -1560,7 +1572,7 @@ to avoid breaking tables that rely on the original behaviour later. The
 
 The \cargv{p\{...\}} specifier allows to insert text with linebreaks into the
 table. The text always starts from the top though, so the \pai{array} package
-defines two additional specifiers \cargv{m\{...\}} for vertically cenetred text
+defines two additional specifiers \cargv{m\{...\}} for vertically centred text
 and \cargv{b\{...\}} for text put vertically at the bottom.
 \begin{example}
 \begin{tabular}{
@@ -1568,7 +1580,7 @@ and \cargv{b\{...\}} for text put vertically at the bottom.
 }
   Cell                 &
   Top matches cell.    &
-  Center matches cell. &
+  Centre matches cell. &
   Bottom matches cell. \\
 \end{tabular}
 \end{example}
@@ -1584,14 +1596,14 @@ can be used to put some code before and after a column.
   l
   >{\begin{em}}l<{\end{em}}
 }
-  normal text & emphasized text \\
-  normal text & emphasized text \\
-  normal text & emphasized text \\
+  normal text & emphasised text \\
+  normal text & emphasised text \\
+  normal text & emphasised text \\
 \end{tabular}
 \end{example}
 
 Some environments change the meaning of the \ci{\textbackslash} command thus
-making it unavailable to go to the next row. In such ocasions you may use the
+making it unavailable to go to the next row. In such occasions you may use the
 \ci{tabularnewline} command.
 \begin{example}
 \begin{tabular}{
@@ -1632,18 +1644,18 @@ it.
 \begin{tabular}{ee}
   This cell will
     be flushed left
-    and emphasized. &
+    and emphasised. &
   This cell will
     be flushed left
-    and emphasized.
+    and emphasised.
   \tabularnewline
 
   This cell will
     be flushed left
-    and emphasized. &
+    and emphasised. &
   This cell will
     be flushed left
-    and emphasized.
+    and emphasised.
   \tabularnewline
 \end{tabular}
 \end{example}
@@ -1692,7 +1704,7 @@ include a picture into your document:
 \item Export the picture from your graphics program in EPS, PDF, PNG or JPEG format.
 \item If you exported your graphics as an EPS vector graphics, you have to convert it to PDF format
 prior to using it. There is a \texttt{epstopdf} command line tool that helps with this task.
-Note that it may be sensible to export EPS eventhough your software can export PDF too, as PDFs often are full page and will
+Note that it may be sensible to export EPS even though your software can export PDF too, as PDFs often are full page and will
 thus get very small when imported into a document. EPS on the other hand come with a bounding box showing the extent of the actual graphics.
 \item Load the \textsf{graphicx} package in the preamble of the input
   file with
@@ -1914,8 +1926,7 @@ rows. If you pass empty optional argument to the \ci{caption} command it will
 typeset normally but it won't be put in the list of tables, which is useful if
 you want to have a running caption.
 
-
-\begin{example}[standalone, template=empty, to_page=2, paperwidth=4.1cm,nocache] 
+\begin{example}[standalone, template=empty, to_page=2, paperwidth=4.1cm] 
 %!hidebegin
 \documentclass{article}
 

--- a/book/src/realworld.tex
+++ b/book/src/realworld.tex
@@ -1116,28 +1116,259 @@ within parameters of other commands.
 
 \subsection{Tabular}
 
-\newcommand{\mfr}[1]{\framebox{\rule{0pt}{0.7em}\texttt{#1}}}
+In \LaTeX{} the environment to typeset tables (and more) is called
+\ei{tabular}. While it can be used on its own, there are some spacing issues,
+so it is recommended to load \pai*{booktabs} which introduces some commands
+that solve the problem. Moreover to achieve some more advanced table layouts
+\pai*{longtable}, \pai*{array} and \pai*{multirow} will also be used in this
+chapter. If your document relies heavily on tables, then it is a good idea to
+put all of those in the preamble.
 
-The \ei{tabular} environment can be used to typeset beautiful
-\wi{table}s with optional horizontal and vertical lines. \LaTeX{}
-determines the width of the columns automatically.
+In addition to commands description, the \pai{booktabs} package documentation
+contains guidelines on typesetting professionally looking tables. These will be
+presented here and you are encouraged to follow them if you want to present
+information contained within the tables clearly.
+
+\subsubsection{Basic tables} \label{foo}
+
+The environment \ei{tabular} has the following form
+\begin{lscommand}
+  \ei*{tabular}[pos:o ! colspec:m]
+\end{lscommand} %
+The \carg{colspec} argument, which stands for columns specifiers, defines the
+format of the table. Use an \cargv{l} for a column of left-aligned text,
+\cargv{r} for right-aligned text, and \cargv{c} for centered text. Inside the
+environment use \ai{\&} to go to next cell within the row and
+\ci{\textbackslash} to go to the next row.
+\begin{example}
+\begin{tabular}{lcr}
+  left & center & right \\
+  1    & 2      & 3     \\
+\end{tabular}
+\end{example}
+Note that the text inside the cells will not be wrapped. If you the column to
+contain justified text with linebreaks use the \cargv{p\{\carg{dim}\}} column
+specifier, where \carg{dim} is the width of the column.
+\begin{example}[examplewidth=0.43\linewidth]
+\begin{tabular}{lrp{3cm}}
+  left & right & very long paragraph
+                 that gets broken into
+                 multiple lines \\
+  1    & 2     & another one,
+                 but shorter \\
+\end{tabular}
+\end{example}
+
+The optional \carg{pos} argument specifies the vertical position of the table
+with respect to baseline of the text. There are three possible alignments:
+\cargv{c} center the table (the default), \cargv{t} matches the baseline of the
+top row and \cargv{b} matches the baseline of the bottom row.
+\begin{example}[examplewidth=0.55\linewidth]
+text
+\begin{tabular}{ll}
+  1 & 2 \\
+  3 & 4 \\
+\end{tabular}
+text
+\begin{tabular}[t]{ll}
+  1 & 2 \\
+  3 & 4 \\
+\end{tabular}
+text
+\begin{tabular}[b]{ll}
+  1 & 2 \\
+  3 & 4 \\
+\end{tabular}
+text
+\end{example}
+
+
+What we have shown so far allows aligning some items in rows and columns,
+but real tables need visible headings. To insert them use commands
+\ci{toprule}, \ci{midrule} and \ci{bottomrule} from the \pai{booktabs} package.
+All of those accept one optional argument that specifies their thickness, but
+usually their defaults are sufficient.
+\begin{example}[examplewidth=0.43\linewidth]
+\begin{tabular}{lcl}
+  \toprule
+  Alignment & Letter & Niceness  \\
+  \midrule
+  Left      & l      & Very nice \\
+  Cener     & c      & Very nice \\
+  Right     & r      & Very nice \\
+  \bottomrule
+\end{tabular}
+\end{example}
+
+With these commands you are already able to produce simple, yet nicely looking
+tables. At this point you may be thinking that this table still needs vertical
+lines between the columns but it is not the case. In fact the first rule of
+producing professionally looking tables is that you must \emph{not} use
+vertical lines.
+
+The second rule is to never use double lines such as these:
+\begin{example}[examplewidth=0.43\linewidth]
+\begin{tabular}{lll}
+  \toprule[0.1cm]
+  \toprule
+  Person      & Face & Table    \\
+  \midrule
+  \midrule
+  Me          & :(   & Not nice \\
+  You         & :[   & Awful    \\
+  Your reader & :<   & Terrible \\
+  \bottomrule
+  \bottomrule[0.1cm]
+\end{tabular}
+\end{example}
+As you can see the lines are already of different weight in order to sifnigy
+their meaning. Using more lines than is necessary means cluttering the space
+without adding information. If you stick to these two rules your tables will
+look \emph{much} better.
+
+To make the tables a bit more sleek you may want to remove the padding in the
+first and last column. To control the space between the columns use the
+\cargv{\@\{\carg{sep}\}} column specifier, where \carg{sep} is either text or
+space. Space of arbitrary length can be inserted using the \ci{hspace}{width}
+command. The contents of the \carg{sep} arguments will be put between cells in
+the relevant column.
+\begin{example}[examplewidth=0.3\linewidth]
+\begin{tabular}{
+  @{a} c @{\hspace{1cm}} c @{|} c @{ b}
+}
+  1 & 2 & 3 \\
+  4 & 5 & 6\\
+  7 & 8 & 9\\
+\end{tabular}
+\end{example}
+If you leave the \carg{sep} empty it will suppress the padding between the
+columns.
+\begin{example}[examplewidth=0.43\linewidth]
+\begin{tabular}{@{}lll@{}}
+  \toprule
+  Person      & Face & Table       \\
+  \midrule
+  Me          & :)   & Nice        \\
+  You         & :]   & Sleek       \\
+  Your reader & :>   & Informative \\
+  \bottomrule
+\end{tabular}
+\end{example}
+
+Sometimes it may make sense to group two or more headings. To achieve this we
+need two things: the description of the group must span multiple columns and
+the line underneath the description should span only the affected columns. In
+order to achieve the first task the 
+\begin{lscommand}
+  \ci*{multicolumn}[ncols:m ! colspec:m ! text:m]
+\end{lscommand}
+command is used. The \carg{ncols} argument indicates how many columns should
+the \carg{text} span, while the \carg{colspec} is the column specification, the
+same as in \ei{tabular}, for the single column the \carg{text} will be put in.
+\begin{example}[examplewidth=0.43\linewidth]
+\begin{tabular}{@{}lll@{}}
+  \toprule
+  Person      & Face & Table       \\
+  \midrule
+  Me          & :)   & Nice        \\
+  You         & :]   & Sleek       \\
+  Your reader & \multicolumn{2}{c}{
+                  Not available}   \\
+  \bottomrule
+\end{tabular}
+\end{example}
+
+To achive a horizontal line that spans multiple columns, use the command
+\begin{lscommand}
+  \ci*{cmidrule}[dim:o ! trim:p ! a--b:m]
+\end{lscommand}
+While the command uses nonstandard syntax for \carg{trim}, this is just an
+optional argument with different pair of delimiters.\footnote{This syntax
+allows to specify the second optional argument without specifying the first,
+which would be impossible if square brackets were used for both.} The
+\carg{dim} allows us to specify the thickness of the line. The \carg{trim}
+argument accepts any combination of \cargv{r}, \cargv{r\{\carg{dim}\}},
+\cargv{l} or \cargv{l\{\carg{dim}\}}. This allows you trim the rule from right
+or left, either by the package default or the specified \carg{dim}. It is
+usually recommended to trim the rules from the side where they touch other
+columns. Finally the only required argument \carg{a--b} is the span of columns
+to draw the line over.
+\begin{example}[examplewidth=0.43\linewidth]
+\begin{tabular}{@{}lll@{}}
+  \toprule
+              & \multicolumn{2}{c}{
+                  Reaction}        \\
+  \cmidrule(l){2-3}
+  Person      & Face & Exclamation \\
+  \midrule
+  Me          & :)   & Nice        \\
+  You         & :]   & Sleek       \\
+  Your reader & \multicolumn{2}{c}{
+                  Not available}   \\
+  \bottomrule
+\end{tabular}
+\end{example}
+
+If you need a cell to span multiple rows instead of columns, then you have to
+use package \pai{multirow}. Its main command is a little more complicated
+\begin{lscommand}
+  \ci*{multirow}[vpos:o ! nrows:m ! bigstruts:o ! width:m ! vmove:o ! text:m]
+\end{lscommand}
+The arguments are
+\begin{description}
+  \item[\carg{vpos}] is the vertical position of the text within the cell.
+    Can be either \cargv{c} for center (the default), \cargv{t} for top or
+    \cargv{b} for bottom.
+  \item[\carg{nrows}] is the number of rows for cell to span.
+  \item[\carg{bigstruts}] is only useful if used with the \pai{bigstrut}
+    package. It will not be discussed here.
+  \item[\carg{width}] is the width of cell. In addition to lengths, you may
+    pass two special arguments here: \cargv{*} for the text natural length and
+    \cargv{=} for the same width as the column (only makes sense if the column
+    width was specified, for example via \cargv{p\{3cm\}}).
+  \item[\carg{vmove}] allows adjusting the position of the text if it is too
+    low or too high. By default no adjusting is done.
+  \item[\carg{text}] is the text to be put in the cell.
+\end{description}
+Unlike with \ci{multicolumn} you still have to write all the cells in remaining
+rows, but they should be empty.
+\begin{example}[examplewidth=0.4\linewidth]
+\begin{tabular}{@{}lll@{}}
+  \toprule
+                & \multicolumn{2}{c}{
+                    Reaction}        \\
+  \cmidrule(l){2-3}
+  Person        & Face & Exclamation \\
+  \midrule
+  \multirow[t]{
+    2}{*}{VIPs} & :)   & Nice        \\
+                & :]   & Sleek       \\
+  Others        & \multicolumn{2}{c}{
+                    Not available}   \\
+  \bottomrule
+\end{tabular}
+\end{example}
+Do not overuse the \ci{multirow} when indicating values common to more than one
+row. Usually repeating the values in question makes it more readable.
+
+
+
+The \ei{tabular} environment can be used to typeset beautiful \wi{table}s.
+\LaTeX{} determines the width of the columns automatically.
 
 The \emph{table spec} argument of the
 \begin{lscommand}
 \verb|\begin{tabular}[|\emph{pos}\verb|]{|\emph{table spec}\verb|}|
 \end{lscommand}
-\noindent command defines the format of the table. Use an \mfr{l} for a column of
-left-aligned text, \mfr{r} for right-aligned text, and \mfr{c} for
-centered text; \mfr{p\{\emph{width}\}} for a column containing justified
-text with line breaks, and \mfr{|} for a vertical line.
+\noindent 
 
 If the text in a column is too wide for the page, \LaTeX{} won't
-automatically wrap it. Using \mfr{p\{\emph{width}\}} you can define
+automatically wrap it. Using \cargv{p\{\emph{width}\}} you can define
 a special type of column which will wrap-around the text as in a normal paragraph.
 
 The \emph{pos} argument specifies the vertical position of the table
 relative to the baseline of the surrounding text.  Use one of the
-letters \mfr{t}, \mfr{b} and \mfr{c} to specify table
+letters \cargv{t}, \cargv{b} and \cargv{c} to specify table
 alignment at the top, bottom or centre.
 
 Within a \texttt{tabular} environment, \texttt{\&} jumps to the next
@@ -1169,11 +1400,11 @@ all enjoy the show.\\
 \end{tabular}
 \end{example}
 
-The column separator can be specified with the \mfr{@\{...\}}
+The column separator can be specified with the \cargv{@\{...\}}
 construct. This command kills the inter-column space and replaces it
 with whatever is between the curly braces. 
 Common application is to suppress leading space in a table with
-\mfr{@\{\}}.
+\cargv{@\{\}}.
 
 \begin{example}
 \begin{tabular}{@{} l @{}}

--- a/book/src/realworld.tex
+++ b/book/src/realworld.tex
@@ -1327,7 +1327,7 @@ The arguments are
     \cargv{=} for the same width as the column (only makes sense if the column
     width was specified, for example via \cargv{p\{3cm\}}).
   \item[\carg{vmove}] allows adjusting the position of the text if it is too
-    low or too high. By default no adjusting is done.
+    low or too tall. By default no adjusting is done.
   \item[\carg{text}] is the text to be put in the cell.
 \end{description}
 Unlike with \ci{multicolumn} you still have to write all the cells in remaining
@@ -1351,7 +1351,187 @@ rows, but they should be empty.
 Do not overuse the \ci{multirow} when indicating values common to more than one
 row. Usually repeating the values in question makes it more readable.
 
+When typesetting numerical data in the table, you may want to align it by
+decimal point. A way to do this (and more) is described in
+section~\ref{sec:sitables}.
 
+\subsubsection{Long tables}
+
+Material typeset with the tabular environment always stays together on one
+page. This poses a problem for especially long tables. If your table is not
+very wide you may get away with it by typesetting its rows side by side. You
+should then put a bigger space between those to indicate that these are
+separate either by using \cargv{@\{...\}} or by putting empty column between
+those.
+\begin{example}[examplewidth=0.4\linewidth]
+\begin{tabular}{@{}cllcl@{}}
+  \toprule
+  Digit & Word  && Digit & Word  \\
+  \midrule
+  0     & Zero  && 5     & Five  \\
+  1     & One   && 6     & Six   \\
+  2     & Two   && 7     & Seven \\
+  3     & Trhee && 8     & Eight \\
+  4     & Four  && 9     & Nine  \\
+  \bottomrule
+\end{tabular}
+\end{example}
+
+This approach will obviously not work for \emph{really} long tables. If you
+must tackle one of those, use the \pai{longtable} package. It defines a new
+\ei{longtable} environment that works similarly to \ei{tabular} environment,
+but allows pagebreaks inside.
+
+\begin{lscommand}
+  \ei*{longtable}[align:o ! colspec:m]
+\end{lscommand}
+In contrast to \ei{tabular}, the \ei{longtable} always starts a new paragraph
+and is centered by default. Thus the optional argument \carg{align} specifies
+whether the table should be centered, on the left or on the right. Use
+\cargv{c}, \cargv{l} and \cargv{r} to specify this. The \carg{colspec} argument
+is the same as in the \ei{tabular} environment.
+
+\begin{example}[standalone, template=empty, to_page=2, paperwidth=4.5cm] 
+%!hidebegin
+\documentclass{article}
+
+\usepackage[paperheight=\height,paperwidth=\width,margin=0.3cm,includefoot]{geometry}
+\usepackage{longtable}
+\usepackage{booktabs}
+\begin{document}
+%!hideend
+\begin{longtable}{cl}
+  \toprule
+  Number & Word   \\
+  \midrule
+  0      & Zero   \\
+  1      & One    \\
+  2      & Two    \\
+  % ...
+%!hidebegin
+  3      & Three \\
+  4      & Four  \\
+  5      & Five  \\
+  6      & Six   \\
+  7      & Seven \\
+  8      & Eight \\
+  9      & Nine  \\
+  10     & Ten       \\
+  11     & Eleven    \\
+  12     & Twelve    \\
+  13     & Thirteen  \\
+  14     & Fourteen  \\
+  15     & Fifteen   \\
+  16     & Sixteen   \\
+  17     & Seventeen \\
+  18     & Eighteen  \\
+  19     & Nineteen  \\
+%!hideend
+  20     & Twenty \\
+  \bottomrule
+\end{longtable}
+\end{document} %!hide
+\end{example}
+
+Note that the pagebreaks are always placed between rows. If you have some tall
+row thanks to \cargv{p\{...\}} specification, it will not broken. 
+\begin{example}[standalone, template=empty, to_page=2, paperwidth=4.5cm] 
+%!hidebegin
+\documentclass{article}
+
+\usepackage[paperheight=\height,paperwidth=\width,margin=0.3cm,includefoot]{geometry}
+\usepackage{longtable}
+\usepackage{booktabs}
+\begin{document}
+%!hideend
+\begin{longtable}{
+  cp{1cm}
+}
+  \toprule
+  Number & Words  \\
+  \midrule
+  0      & Zero   \\
+  1      & Multi
+           paragraph
+           text.
+
+           It makes
+           the table
+           cell very
+           tall.  \\
+  2      & Two    \\
+  \bottomrule
+\end{longtable}
+\end{document} %!hide
+\end{example}
+
+The \ei{longtable} environment defines also some additional commands that end
+table rows. One of them is \ci{\textbackslash*} which, similarly to its
+paragraph use, prohibits pagebreak after the row. Another useful commands are
+\ci{endhead}, \ci{endfirsthead}, \ci{endfoot} and \ci{endlastfoot}. If you end
+the row with them they will set the preceding rows as headers and footers of
+the table. The \ci{endhead} and \ci{endfoot} put the headers and footers on
+every page while \ci{endfirsthead} and \ci{endlastfoot} put them on the first
+and last page. An example of using these commands is presented in
+figure~\ref{ex:longtable} on page~\pageref{ex:longtable}.
+\begin{figure}[htp]
+\begin{example}[standalone, template=empty, to_page=2, paperwidth=4.3cm,nocache] 
+%!hidebegin
+\documentclass{article}
+
+\usepackage[paperheight=\height,paperwidth=\width,margin=0.3cm,includefoot]{geometry}
+\usepackage{longtable}
+\usepackage{booktabs}
+\begin{document}
+%!hideend
+\begin{longtable}{cl}
+  \toprule
+  \multicolumn{2}{c}{
+    V.~Important Table} \\
+  Number & Word         \\
+  \midrule \endfirsthead
+
+  \toprule
+  \multicolumn{2}{c}{
+    VIT (continued)} \\
+  Number & Word      \\
+  \midrule \endhead
+
+  \midrule
+  \multicolumn{2}{c}{
+    Not the end} \\
+  \bottomrule \endfoot
+
+  \midrule
+  \multicolumn{2}{c}{
+    The end of VIT} \\
+  \bottomrule \endlastfoot
+
+  0      & Zero   \\
+  1      & One    \\
+  % ...
+%!hidebegin
+  2      & Two     \\
+  3      & Three \\
+  4      & Four  \\
+  5      & Five  \\
+  6      & Six   \\
+  7      & Seven \\
+  8      & Eight \\
+  9      & Nine  \\
+  10     & Ten    \\
+  11     & Eleven \\
+  %!hideend
+  12     & Twelve \\
+\end{longtable}
+\end{document} %!hide 
+\end{example}
+\caption{An example of \ei{longtable} with running headers and footers.} \label{ex:longtable}
+\end{figure}
+
+Note that while you can use \ci{multicolumn} and \ci{multirow} normally within
+the \ei{longtable} environemnt, the table may get very complicated and \LaTeX{}
+will then need several passes to properly calculate the column widths.
 
 The \ei{tabular} environment can be used to typeset beautiful \wi{table}s.
 \LaTeX{} determines the width of the columns automatically.
@@ -1425,9 +1605,6 @@ leading space left and right\\
 %
 % This part by Mike Ressler
 %
-
-When typesetting numerical data in the table, you may want to align it by
-decimal point. A way to do this will be described in section~\ref{sec:sitables}.
 
 \begin{example}
 \begin{tabular}{|c|c|}
@@ -1714,6 +1891,63 @@ Under certain circumstances it might be necessary to use the
 \noindent command. It orders \LaTeX{} to immediately place all
 floats remaining in the queues and then start a new
 page. \ci{cleardoublepage} even goes to a new right-hand page.
+
+\subsection{The \ei{longtable} environment}
+
+Floating bodies occupy only a single page, thus putting \ei{longtable} into
+them does not make sense. Still you may want to have the \ei{longtable} listed
+in the list of tables with some caption. The \pai{longtable} package defines
+its own \ci{caption} command that you may use inside the environment. Its use
+is similar to the standard \ci{caption} command except that they are treated as
+rows. If you pass empty optional argument to the \ci{caption} command it will
+typeset normally but it won't be put in the list of tables, which is useful if
+you want to have a running caption.
+
+
+\begin{example}[standalone, template=empty, to_page=2, paperwidth=4.1cm,nocache] 
+%!hidebegin
+\documentclass{article}
+
+\usepackage[paperheight=\height,paperwidth=\width,margin=0.3cm,includefoot]{geometry}
+\usepackage{longtable}
+\usepackage{booktabs}
+
+\begin{document}
+%!hideend
+\begin{longtable}{cl}
+  \caption{Numbers} \\
+  \toprule
+  Number & Word         \\
+  \midrule \endfirsthead
+
+  \caption[]{(continued)} \\
+  \toprule
+  Number & Word      \\
+  \midrule \endhead
+
+  \bottomrule \endfoot
+  \bottomrule \endlastfoot
+
+  0      & Zero   \\
+  1      & One    \\
+  % ...
+%!hidebegin
+  2      & Two     \\
+  3      & Three \\
+  4      & Four  \\
+  5      & Five  \\
+  6      & Six   \\
+  7      & Seven \\
+  8      & Eight \\
+  9      & Nine  \\
+  10     & Ten    \\
+  11     & Eleven \\
+  %!hideend
+  12     & Twelve \\
+\end{longtable}
+\end{document} %!hide 
+\end{example}
+
 
 % Local Variables:
 % TeX-master: "lshort2e"

--- a/book/src/realworld.tex
+++ b/book/src/realworld.tex
@@ -249,17 +249,18 @@ In some of the examples on the previous pages, you have seen
 some very simple \LaTeX{} commands for typesetting special
 text strings:
 
-\vspace{2ex}
-
-\noindent
-\begin{tabular}{@{}lll@{}}
-Command&Example&Description\\
-\hline
-\ci{today} & \today   & Current date\\
-\ci{TeX} & \TeX       & Your favorite typesetter\\
-\ci{LaTeX} & \LaTeX   & The Name of the Game\\
-\ci{LaTeXe} & \LaTeXe & The current incarnation\\
-\end{tabular}
+\begin{center}
+  \begin{tabular}{@{}lll@{}}
+    \toprule
+    Command     & Example & Description\\
+    \midrule
+    \ci{today}  & \today  & Current date\\
+    \ci{TeX}    & \TeX    & Your favorite typesetter\\
+    \ci{LaTeX}  & \LaTeX  & The Name of the Game\\
+    \ci{LaTeXe} & \LaTeXe & The current incarnation\\
+    \bottomrule
+  \end{tabular}
+\end{center}
 
 \section{Special Characters and Symbols}
 
@@ -357,14 +358,19 @@ If you prefer a Euro symbol that matches your font, use the option
 
 \begin{table}[!htbp]
   \centering
-\caption{A bag full of Euro symbols} \label{eurosymb}
+\caption[Available Euro symbols]{The appearance of available Euro symbols based
+on the loaded package and the used font.} \label{eurosymb}
 \begin{tabular}{@{}llccc@{}}
 \toprule
-LM+textcomp  &\verb+\texteuro+ & \huge\texteuro &\huge\sffamily\texteuro
+&& \multicolumn{3}{c}{Symbol used} \\
+\cmidrule(l){3-5}
+Package & Command & Roman & Sans serif & Monospace \\
+\midrule
+LM+textcomp  &\ci{texteuro} & \huge\texteuro &\huge\sffamily\texteuro
                                                 &\huge\ttfamily\texteuro\\
-eurosym      &\verb+\euro+ & \huge\officialeuro &\huge\sffamily\officialeuro
+eurosym      &\ci{euro} & \huge\officialeuro &\huge\sffamily\officialeuro
                                                 &\huge\ttfamily\officialeuro\\
-$[$gen$]$eurosym &\verb+\euro+ & \huge\geneuro  &\huge\sffamily\geneuro
+$[$gen$]$eurosym &\ci{euro} & \huge\geneuro  &\huge\sffamily\geneuro
                                                 &\huge\ttfamily\geneuro\\
 %europs       &\verb+\EUR + & \huge\EURtm        &\huge\EURhv
 %                                                &\huge\EURcr\\
@@ -432,17 +438,19 @@ Stra\ss e
 \begin{table}[!hbp]
   \centering
 \caption{Accents and Special Characters.} \label{accents}
-\begin{tabular}{@{}*4{cl}@{}}
+\begin{tabular}{@{}*3{ll@{\qquad}}ll@{}}
   \toprule
-\mstA{\`o} & \mstA{\'o} & \mstA{\^o} & \mstA{\~o} \\
-\mstA{\=o} & \mstA{\.o} & \mstA{\"o} & \mstB{\c}{c}\\[6pt]
-\mstB{\u}{o} & \mstB{\v}{o} & \mstB{\H}{o} & \mstB{\c}{o} \\
-\mstB{\d}{o} & \mstB{\b}{o} & \mstB{\t}{oo} \\[6pt]
-\mstA{\oe}  &  \mstA{\OE} & \mstA{\ae} & \mstA{\AE} \\
-\mstA{\aa} &  \mstA{\AA} \\[6pt]
-\mstA{\o}  & \mstA{\O} & \mstA{\l} & \mstA{\L} \\
-\mstA{\i}  & \mstA{\j} & !` & \verb|!`| & ?` & \verb|?`| \\
-\bottomrule
+  Code & Effect & Code & Effect & Code& Effect & Code & Effect \\
+  \midrule
+  \mstA{\`o} & \mstA{\'o} & \mstA{\^o} & \mstA{\~o} \\
+  \mstA{\=o} & \mstA{\.o} & \mstA{\"o} & \mstB{\c}{c}\\[6pt]
+  \mstB{\u}{o} & \mstB{\v}{o} & \mstB{\H}{o} & \mstB{\c}{o} \\
+  \mstB{\d}{o} & \mstB{\b}{o} & \mstB{\t}{oo} && \\[6pt]
+  \mstA{\oe}  &  \mstA{\OE} & \mstA{\ae} & \mstA{\AE} \\
+  \mstA{\aa} &  \mstA{\AA} &&&& \\[6pt]
+  \mstA{\o}  & \mstA{\O} & \mstA{\l} & \mstA{\L} \\
+  \mstA{\i}  & \mstA{\j} & !` & \verb|!`| & ?` & \verb|?`| \\
+  \bottomrule
 \end{tabular}
 \index{dotless \i{} and \j}\index{Scandinavian letters}
 \index{ae@\ae}\index{umlaut}\index{grave}\index{acute}
@@ -1728,10 +1736,12 @@ most important keys.
 \label{keyvals}
 \begin{tabular}{@{}ll@{}}
   \toprule
-\texttt{width}& scale graphic to the specified width\\
-\texttt{height}& scale graphic to the specified height\\
-\texttt{angle}& rotate graphic counterclockwise\\
-\texttt{scale}& scale graphic \\
+  Key & Effect \\
+  \midrule
+  \cargv{width}& scale graphic to the specified width\\
+  \cargv{height}& scale graphic to the specified height\\
+  \cargv{angle}& rotate graphic counterclockwise\\
+  \cargv{scale}& scale graphic \\
 \bottomrule
 \end{tabular}
 

--- a/book/src/spec.tex
+++ b/book/src/spec.tex
@@ -51,15 +51,15 @@ point to.  Table~\ref{index} explains the syntax with several examples.
 \label{index}
 \begin{tabular}{@{}lll@{}}
   \toprule
-  Example &Index Entry &Comment\\\midrule
+  Code &Index Entry &Comment\\
+  \midrule
   \rule{0pt}{1.05em}\verb|\index{hello}| &hello, 1 &Plain entry\\
-\verb|\index{hello!Peter}|   &\hspace*{2ex}Peter, 3 &Subentry under `hello'\\
-\verb|\index{Sam@\textsl{Sam}}|     &\textsl{Sam}, 2& Formatted entry\\
-\verb|\index{Lin@\textbf{Lin}}|     &\textbf{Lin}, 7& Formatted entry\\
-\verb|\index{Kaese@\textbf{K\"ase}}|     &\textbf{K\"ase}, 33& Formatted entry\\
-\verb.\index{ecole@\'ecole}.     &\'ecole, 4& Formatted entry\\
-\verb.\index{Jenny|textbf}.     &Jenny, \textbf{3}& Formatted page number\\
-\verb.\index{Joe|textit}.     &Joe, \textit{5}& Formatted page number\\
+  \verb|\index{hello!Peter}|   &\hspace*{2ex}Peter, 3 &Subentry under `hello'\\
+  \verb|\index{Sam@\emph{Sam}}|     &\emph{Sam}, 2& Formatted entry\\
+  \verb|\index{Kaese@\emph{K\"ase}}|     &\emph{K\"ase}, 33& Formatted entry\\
+  \verb.\index{ecole@\'ecole}.     &\'ecole, 4& Formatted entry\\
+  \verb.\index{Jenny|emph}.     &Jenny, \emph{3}& Formatted page number\\
+  \verb.\index{Joe@\emph{Joe}|emph}.     &\emph{Joe}, \emph{5}& Formatted page number\\
 \bottomrule
 \end{tabular}
 \end{table}
@@ -316,23 +316,23 @@ list the default values are written in an upright font.
 
 \begin{flushleft}
 \begin{description}
-  \item [\texttt{bookmarks (=true,\textit{false})}] show or hide the
+  \item [\texttt{bookmarks (=true,\textsl{false})}] show or hide the
     bookmarks bar when displaying the document
-  \item [\texttt{unicode (=false,\textit{true})}] allows the use of
+  \item [\texttt{unicode (=false,\textsl{true})}] allows the use of
     characters of non-Latin based languages in Acrobat's bookmarks
-  \item [\texttt{pdftoolbar (=true,\textit{false})}] show or hide
+  \item [\texttt{pdftoolbar (=true,\textsl{false})}] show or hide
     Acrobat's toolbar
-  \item [\texttt{pdfmenubar (=true,\textit{false})}] show or hide
+  \item [\texttt{pdfmenubar (=true,\textsl{false})}] show or hide
     Acrobat's menu
-  \item [\texttt{pdffitwindow (=false,\textit{true})}] adjust the
+  \item [\texttt{pdffitwindow (=false,\textsl{true})}] adjust the
     initial magnification of the PDF when displayed
   \item [\texttt{pdftitle (=\{text\})}] define the title that gets
     displayed in the \texttt{Document Info} window of Acrobat
   \item [\texttt{pdfauthor (=\{text\})}] the name of the PDF's author
-  \item [\texttt{pdfnewwindow (=false,\textit{true})}] define whether a new
+  \item [\texttt{pdfnewwindow (=false,\textsl{true})}] define whether a new
     window should be opened when a link leads out of the current
     document
-  \item [\texttt{colorlinks (=false,\textit{true})}] surround the
+  \item [\texttt{colorlinks (=false,\textsl{true})}] surround the
     links by colour frames (\texttt{false}) or colour the text of the links
     (\texttt{true}). The colour of these links can be configured
     using the following options (default colours are shown):
@@ -537,8 +537,12 @@ for tables.
 \begin{verbatim}
 \newfontfamily\LLln[Numbers=Lining]{(font)}
 \newfontfamily\LLos[Numbers=OldStyle]{(font)}
-\newfontfamily\LLlnm[Numbers=Lining,Numbers=Monospaced]{(font)}
-\newfontfamily\LLosm[Numbers=OldStyle,Numbers=Monospaced]{(font)}
+\newfontfamily\LLlnm[
+  Numbers=Lining,Numbers=Monospaced
+]{(font)}
+\newfontfamily\LLosm[
+  Numbers=OldStyle,Numbers=Monospaced
+]{(font)}
 \end{verbatim}
 \end{code}
 

--- a/book/src/title.template.tex
+++ b/book/src/title.template.tex
@@ -26,7 +26,7 @@ Introduction to \LaTeXe
 \noindent\hspace*{\centeroffset}\makebox[0pt][l]{\begin{minipage}{\textwidth}
 \flushright
 {\bfseries 
-by Tobias Oetiker\\[1.5ex]
+by Tobias Oetiker, Marcin Serwin\\[1.5ex]
 Hubert Partl, Irene Hyna and  Elisabeth Schlegl\\[3ex]} 
 Version~6.4, March 09, 2021
 \end{minipage}}


### PR DESCRIPTION
This PR rewrites the introduction on tables to be more focused on `booktabs` package and adds examples of using the `longtable` and `array` packages. Tables throughout the document were also improved by adding to them uniform headers.