### PR TITLE
Fix typos in realworld.tex

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,6 @@
 ## UNRELEASED
 
+- fix accent table mixup @Samuel-Martineau
 - improve wording regarding latex symbols and where to look them up
   since we removed the integrated list of symbols. @oetiker
 - replace sec:this with my-marker in the crosref section @oetiker

--- a/src/realworld.tex
+++ b/src/realworld.tex
@@ -323,7 +323,7 @@ output is produced only if the font supports the combination. The example above 
 look like this if entered on an english keyboard:
 \begin{chktexignore}
 \begin{example}[examplewidth=0.4\textwidth]
-H\^otel, na\"{\i}ve, \'el\`ve, \\
+H\^otel, na\"{\i}ve, \'el\`eve, \\
 sm{\o}rrebr{\o}d, !`Se\~norita!, \\
 Sch\"onbrunner Schlo\ss, \.Z\'o\l\'c
 \end{example}
@@ -342,7 +342,7 @@ Sch\"onbrunner Schlo\ss, \.Z\'o\l\'c
     \mstA{\oe}   & \mstA{\OE}   & \mstA{\ae}    & \mstA{\AE}                                      \\
     \mstA{\aa}   & \mstA{\AA}   &               &              &      &                           \\[6pt]
     \mstA{\o}    & \mstA{\O}    & \mstA{\l}     & \mstA{\L}                                       \\
-    \mstA{\i}    & \mstA{\j}    & !`            & \verb|!`|    & ?`   & \verb|?`|                 \\ %chktex 26
+    \mstA{\i}    & \mstA{\j}    & \verb|!`|     & !`    & \verb|?`| &  ?`                         \\ %chktex 26
     \bottomrule
   \end{tabular}%
   \index{dotless \i{} and \j}\index{Scandinavian letters}%


### PR DESCRIPTION
While reading the book (frankly amazing, I must say), I stumbled across what I believe to be a few typos in the Real World LaTeX chapter. If they are not, sorry for the disturbance.