### PR TITLE
Add workarounds for minted bugs

### DIFF
--- a/.chktexrc
+++ b/.chktexrc
@@ -1,5 +1,5 @@
 CmdLine {
-    -eall -n22 -n30 -e16 -n46 -n21 -n29 -n3 -n17 -n11
+    -eall -n22 -n30 -e16 -n46 -n21 -n29 -n3 -n17 -n11 -n12
 }
 
 VerbEnvir {
@@ -13,6 +13,7 @@ Silent {
     \tabularnewline \ifpdf \ExplSyntaxOn \ExplSyntaxOff
     \bgroup \egroup \sourcefamily \restoregeometry
     \itshape \cleardoublepage \IfValueT \pause \blindtext
+    \backmatter
 }
 
 MathEnvir {

--- a/src/bibliography.tex
+++ b/src/bibliography.tex
@@ -395,10 +395,10 @@ options include
 \end{example}
 
 As you may have noticed, when entries have many authors, then not all of
-them will be printed; instead ``et al.'' shows up at the end of the author list. This behaviour
+them will be printed; instead \enquote{et al.} shows up at the end of the author list. This behaviour
 may be controlled via \cargv{maxnames} (default $3$) and \cargv{minnames}
 (default $1$) options. If the number of names is greater than \carg{maxnames}
-then it will be shortened to \carg{minnames} and ``et al.'' will be added.
+then it will be shortened to \carg{minnames} and \enquote{et al.} will be added.
 
 \begin{example}[standalone,
   biber,

--- a/src/deprecated.tex
+++ b/src/deprecated.tex
@@ -55,8 +55,8 @@
   \begin{trivlist}
     \item
     % Workaround for https://github.com/gpoore/minted/issues/356
-    \RenewCommandCopy\VerbEnv\Verbatim
-    \RenewCommandCopy\endVerbEnv\endVerbatim
+    \RenewCommandCopy{\VerbEnv}{\Verbatim}
+    \RenewCommandCopy{\endVerbEnv}{\endVerbatim}
     \begin{minipage}{0.4\textwidth}
       \mintinline{latex}:#1:
     \end{minipage}
@@ -71,8 +71,8 @@
 \NewDocumentCommand{\vchto}{+v+v}{
   \begin{center}
     % Workaround for https://github.com/gpoore/minted/issues/356
-    \RenewCommandCopy\VerbEnv\Verbatim
-    \RenewCommandCopy\endVerbEnv\endVerbatim
+    \RenewCommandCopy{\VerbEnv}{\Verbatim}
+    \RenewCommandCopy{\endVerbEnv}{\endVerbatim}
     \mintinline{latex}:#1:
     \(\big\downarrow\)\\[.2cm]
     \mintinline{latex}:#2:

--- a/src/deprecated.tex
+++ b/src/deprecated.tex
@@ -54,6 +54,9 @@
 \NewDocumentCommand{\chto}{+v+v}{
   \begin{trivlist}
     \item
+    % Workaround for https://github.com/gpoore/minted/issues/356
+    \RenewCommandCopy\VerbEnv\Verbatim
+    \RenewCommandCopy\endVerbEnv\endVerbatim
     \begin{minipage}{0.4\textwidth}
       \mintinline{latex}:#1:
     \end{minipage}
@@ -67,7 +70,10 @@
 }
 \NewDocumentCommand{\vchto}{+v+v}{
   \begin{center}
-    \mintinline{latex}:#1:\\[.2cm]
+    % Workaround for https://github.com/gpoore/minted/issues/356
+    \RenewCommandCopy\VerbEnv\Verbatim
+    \RenewCommandCopy\endVerbEnv\endVerbatim
+    \mintinline{latex}:#1:
     \(\big\downarrow\)\\[.2cm]
     \mintinline{latex}:#2:
   \end{center}
@@ -155,7 +161,7 @@ optional argument with default value (specified as second optional argument)
 followed by few mandatory ones (specified as number in first optional
 argument).
 \begin{chktexignore}
-  \vchto|\newcommand{\foo}[4][bar]{ ... }|
+  \vchto|\newcommand{\foo}[4][bar]{ ... }|%
   |\NewDocumentCommand{\foo}{O{bar}mmmm}{ ... }|
 \end{chktexignore}
 

--- a/src/lshort.sty
+++ b/src/lshort.sty
@@ -63,6 +63,7 @@
   Script=Arabic,
 }
 \newfontfamily\arabicfonttt{Iran Nastaliq}
+\newfontfamily\arabicfont{Iran Nastaliq}
 \newfontface\@swash[
   Style=Swash,
 ]{EB Garamond}

--- a/src/lshortexample.sty
+++ b/src/lshortexample.sty
@@ -368,3 +368,10 @@
     }
   }
 }
+
+% Workaround for https://github.com/gpoore/minted/issues/354
+\ifwindows
+  \def\minted@opt@quote#1{\detokenize\expandafter{\expandafter"\expanded{#1}"}}
+\else
+  \def\minted@opt@quote#1{\detokenize\expandafter{\expandafter'\expanded{#1}'}}
+\fi

--- a/src/realworld.tex
+++ b/src/realworld.tex
@@ -333,16 +333,16 @@ Sch\"onbrunner Schlo\ss, \.Z\'o\l\'c
   \caption{Accents and Special Characters.}\label{accents}
   \begin{tabular}{@{}*3{ll@{\qquad}}ll@{}}
     \toprule
-    Code         & Result       & Code          & Result       & Code & Result    & Code & Result \\
+    Code         & Result       & Code          & Result       & Code      & Result & Code & Result \\
     \midrule
-    \mstA{\`o}   & \mstA{\'o}   & \mstA{\^o}    & \mstA{\~o}                                      \\
-    \mstA{\=o}   & \mstA{\.o}   & \mstA{\"o}    & \mstB{\c}{c}                                    \\[6pt]
-    \mstB{\u}{o} & \mstB{\v}{o} & \mstB{\H}{o}  & \mstB{\k}{a}                                    \\
-    \mstB{\d}{o} & \mstB{\b}{o} & \mstB{\t}{oo} & \mstB{\r}{o}                                    \\[6pt]
-    \mstA{\oe}   & \mstA{\OE}   & \mstA{\ae}    & \mstA{\AE}                                      \\
-    \mstA{\aa}   & \mstA{\AA}   &               &              &      &                           \\[6pt]
-    \mstA{\o}    & \mstA{\O}    & \mstA{\l}     & \mstA{\L}                                       \\
-    \mstA{\i}    & \mstA{\j}    & \verb|!`|     & !`    & \verb|?`| &  ?`                         \\ %chktex 26
+    \mstA{\`o}   & \mstA{\'o}   & \mstA{\^o}    & \mstA{\~o}                                        \\
+    \mstA{\=o}   & \mstA{\.o}   & \mstA{\"o}    & \mstB{\c}{c}                                      \\[6pt]
+    \mstB{\u}{o} & \mstB{\v}{o} & \mstB{\H}{o}  & \mstB{\k}{a}                                      \\
+    \mstB{\d}{o} & \mstB{\b}{o} & \mstB{\t}{oo} & \mstB{\r}{o}                                      \\[6pt]
+    \mstA{\oe}   & \mstA{\OE}   & \mstA{\ae}    & \mstA{\AE}                                        \\
+    \mstA{\aa}   & \mstA{\AA}   &               &              &           &                        \\[6pt]
+    \mstA{\o}    & \mstA{\O}    & \mstA{\l}     & \mstA{\L}                                         \\
+    \mstA{\i}    & \mstA{\j}    & \verb|!`|     & !`           & \verb|?`| & ?`                     \\ %chktex 26
     \bottomrule
   \end{tabular}%
   \index{dotless \i{} and \j}\index{Scandinavian letters}%


### PR DESCRIPTION
Since version 2.7 `minted` is using new input processing macros which are not entirely backwards compatible. This breaks our CI since we were relying on some old behaviors. This PR adds workarounds for two bugs that prevented the book from building with the newest `minted`.

Fixes #90 