### PR TITLE
Fix build

### DIFF
--- a/src/custom.tex
+++ b/src/custom.tex
@@ -1272,10 +1272,12 @@ Boxes are explored further in \autoref{sec:boxes}.
     number-mode=text,
     parse-numbers=false,
   ]{
-    \sfrac{
-      \num[number-mode=math,parse-numbers=true]{#1}
-    }{
-      \num[number-mode=math,parse-numbers=true]{#2}
+  \text{
+      \sfrac{
+        \num[number-mode=math,parse-numbers=true]{#1}
+      }{
+        \num[number-mode=math,parse-numbers=true]{#2}
+      }
     }
   }
 }
@@ -1284,11 +1286,12 @@ Boxes are explored further in \autoref{sec:boxes}.
   \qty[
     number-mode=text,
     parse-numbers=false,
-  ]{
-    \sfrac{
-      \num[number-mode=math,parse-numbers=true]{#1}
-    }{
-      \num[number-mode=math,parse-numbers=true]{#2}
+  ]{\text{
+      \sfrac{
+        \num[number-mode=math,parse-numbers=true]{#1}
+      }{
+        \num[number-mode=math,parse-numbers=true]{#2}
+      }
     }
   }{#3}
 }

--- a/src/deprecated.tex
+++ b/src/deprecated.tex
@@ -51,6 +51,8 @@
   }
 }
 
+% FIXME: The commands below no longer work as expected due to the changed
+% handling of newlines in +v params, see https://tex.stackexchange.com/a/722462.
 \NewDocumentCommand{\chto}{+v+v}{
   \begin{trivlist}
     \item

--- a/src/lshort.sty
+++ b/src/lshort.sty
@@ -73,7 +73,7 @@
 \RequirePackage{verbatim}
 \RequirePackage{listings}
 \RequirePackage{flafter}
-\RequirePackage[kpsewhich, cachedir=pdfbuild/minted_cache, chapter]{minted}
+\RequirePackage[cachedir=pdfbuild/minted_cache, chapter]{minted}
 \setminted{
   escapeinside=«»,
 }

--- a/src/lshortexample.sty
+++ b/src/lshortexample.sty
@@ -368,10 +368,3 @@
     }
   }
 }
-
-% Workaround for https://github.com/gpoore/minted/issues/354
-\ifwindows
-  \def\minted@opt@quote#1{\detokenize\expandafter{\expandafter"\expanded{#1}"}}
-\else
-  \def\minted@opt@quote#1{\detokenize\expandafter{\expandafter'\expanded{#1}'}}
-\fi


### PR DESCRIPTION
Remove some workarounds and deprecated options, fixes #98.

The deprecations chapter does not render correctly due to changed handling of newlines. It shouldn't be hard to fix with some l3expl replacements but I haven't used them for some time now and I don't have time to relearn it, I left a fixme comment there.