### PR TITLE
Enumerate outputted example files

### DIFF
--- a/src/lshortexample.sty
+++ b/src/lshortexample.sty
@@ -50,6 +50,8 @@
 %%%
 
 \tl_new:N \__lshortexample_example_label
+\tl_new:N \__lshortexample_verbatim_input_file
+\tl_new:N \__lshortexample_verbatim_output_file
 \int_new:N \__lshortexample_example_counter
 \bool_new:N \__lshortexample_hide_switch
 \bool_new:N \__lshortexample_show_switch
@@ -87,12 +89,6 @@
   examplewidth .tl_set:N = \__lshortexample_examplewidth,
   examplewidth .initial:n = 0.5\linewidth,
 
-  verbatim_input_file_name .tl_set:N = \__lshortexample_verbatim_input_file,
-  verbatim_input_file_name .initial:n = {\c_sys_jobname_str _input.exa},
-
-  verbatim_output_file_name .tl_set:N = \__lshortexample_verbatim_output_file,
-  verbatim_output_file_name .initial:n = {\c_sys_jobname_str _output.exa},
-
   from_page .int_set:N  = \__lshortexample_from_page,
   from_page .initial:n  = 1,
 
@@ -117,6 +113,13 @@
 }
 
 \NewDocumentEnvironment{example}{!o} {
+  \tl_set:Nx \__lshortexample_verbatim_input_file {
+    \c_sys_jobname_str _example_ \int_use:N\__lshortexample_example_counter _input.tex
+  }
+  \tl_set:Nx \__lshortexample_verbatim_output_file {
+    \c_sys_jobname_str _example_ \int_use:N\__lshortexample_example_counter _output.tex
+  }
+
   \group_begin:
   \IfValueT {#1} {
     \keys_set:nn { lshortexample } { #1 }


### PR DESCRIPTION
This should fix the issue with overwriting input files for minted mentioned in https://github.com/oetiker/lshort/pull/95#issuecomment-2863175625.